### PR TITLE
Correctly turn off Codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,1 +1,1 @@
-comment: false
+comment: off


### PR DESCRIPTION
The syntax in the YAML file was off.

These comments make me crazy.