### PR TITLE
Dropterm

### DIFF
--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -21,6 +21,7 @@ export @~,
        ContrastsCoding,
 
        coefnames,
+       dropterm,
        setcontrasts!
 
 map(include,

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -229,10 +229,10 @@ Return a copy of `f` without the term `trm`.
 
 # Examples
 ```jl
-julia> dropterm(foo ~ 1 + bar + baz, :bar)
+julia> dropterm(@formula(foo ~ 1 + bar + baz), :bar)
 Formula: foo ~ 1 + baz
 
-julia> dropterm(foo ~ 1 + bar + baz, 1)
+julia> dropterm(@formula(foo ~ 1 + bar + baz), 1)
 Formula: foo ~ 0 + bar + baz
 ```
 """

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -24,6 +24,8 @@ macro ~(lhs, rhs)
     return ex
 end
 
+Base.:(==)(f1::Formula, f2::Formula) = all(getfield(f1, f)==getfield(f2, f) for f in fieldnames(f1))
+
 """
 Representation of parsed `Formula`
 

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -213,3 +213,23 @@ function Formula(t::Terms)
     append!(rhs.args,t.terms)
     Formula(lhs,rhs)
 end
+
+"""
+    dropterm(f::Formula, trm::Symbol)
+
+Return a copy of `f` without the term `trm`.
+
+# Examples
+```jl
+julia> dropterm(foo ~ 1 + bar + baz, :bar)
+foo ~ 1 + baz
+```
+"""
+function dropterm(f::Formula, trm::Symbol)
+    rhs = copy(f.rhs)
+    args = rhs.args
+    if !(Meta.isexpr(rhs, :call) && args[1] == :+ && (tpos = findlast(args, trm)) > 0)
+        throw(ArgumentError("$trm is not a summand in `$rhs`"))
+    end
+    Formula(f.lhs, Expr(:call, :+, deleteat!(args, [1, tpos])...))
+end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -105,14 +105,14 @@ t = Terms(@formula(y ~ x1 * x2 * x3))
 ## @test t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
 ## @test t.eterms == [:y, :x1, :x2]
 
-@test dropterm(foo ~ 1 + bar + baz, :bar) == (foo ~ 1 + baz)
-@test dropterm(foo ~ 1 + bar + baz, 1) == (foo ~ 0 + bar + baz)
-@test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, 0)
-@test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, :boz)
-form = foo ~ 1 + bar + baz
-@test form == (foo ~ 1 + bar + baz)
-@test StatsModels.dropterm!(form, :bar) == (foo ~ 1 + baz)
-@test form == (foo ~ 1 + baz)
+@test dropterm(@formula(foo ~ 1 + bar + baz), :bar) == @formula(foo ~ 1 + baz)
+@test dropterm(@formula(foo ~ 1 + bar + baz), 1) == @formula(foo ~ 0 + bar + baz)
+@test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), 0)
+@test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), :boz)
+form = @formula(foo ~ 1 + bar + baz)
+@test form == @formula(foo ~ 1 + bar + baz)
+@test StatsModels.dropterm!(form, :bar) == @formula(foo ~ 1 + baz)
+@test form == @formula(foo ~ 1 + baz)
 
 # Incorrect formula separator
 @test_throws ErrorException eval(:(@formula(y => x + 1)))

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -106,9 +106,12 @@ t = Terms(y ~ x1 * x2 * x3)
 ## @test t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
 ## @test t.eterms == [:y, :x1, :x2]
 
-@test dropterm(foo ~ 1 + bar + baz, :bar).rhs == :(1 + baz)
-@test dropterm(foo ~ 1 + bar + baz, 1).rhs == :(0 + bar + baz)
+@test dropterm(foo ~ 1 + bar + baz, :bar) == (foo ~ 1 + baz)
+@test dropterm(foo ~ 1 + bar + baz, 1) == (foo ~ 0 + bar + baz)
 @test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, 0)
 @test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, :boz)
-
+form = foo ~ 1 + bar + baz
+@test form == (foo ~ 1 + bar + baz)
+@test StatsModels.dropterm!(form, :bar) == (foo ~ 1 + baz)
+@test form == (foo ~ 1 + baz)
 end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -106,4 +106,9 @@ t = Terms(y ~ x1 * x2 * x3)
 ## @test t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
 ## @test t.eterms == [:y, :x1, :x2]
 
+@test dropterm(foo ~ 1 + bar + baz, :bar).rhs == :(1 + baz)
+@test dropterm(foo ~ 1 + bar + baz, 1).rhs == :(0 + bar + baz)
+@test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, 0)
+@test_throws ArgumentError dropterm(foo ~ 0 + bar + baz, :boz)
+
 end


### PR DESCRIPTION
I think it would help to have functions for manipulating formulas.  `dropterm` is easy to define.  Methods could be added for a collection of `Symbol`s or expressions.  The reason I use this is to perform an analysis of deviance on a `GeneralizedLinearModel` (i.e. fit the original model, drop a term and fit the null model, evaluate the change in deviance).
