### PR TITLE
Update Terms for Julia 0.6 changes

### DIFF
--- a/src/formula.jl
+++ b/src/formula.jl
@@ -176,8 +176,8 @@ evt(a) = Any[a]
 function Terms(f::Formula)
     rhs = condense(distribute(dospecials(f.rhs)))
     tt = unique(getterms(rhs))
-    tt = tt[!(tt .== 1)]             # drop any explicit 1's
-    noint = (tt .== 0) | (tt .== -1) # should also handle :(-(expr,1))
+    filter!(t -> t != 1, tt)                          # drop any explicit 1's
+    noint = BitArray(map(t -> t == 0 || t == -1, tt)) # should also handle :(-(expr,1))
     tt = tt[!noint]
     oo = Int[ord(t) for t in tt]     # orders of interaction terms
     if !issorted(oo)                 # sort terms by increasing order


### PR DESCRIPTION
This does a couple of things:
* `tt` is inferred as `Array{Any,1}`, as is `tt .== 1`, so `!(tt .== 1)` fails. Changed to `filter!`.
* Vectorized `|` is deprecated and `.|` doesn't exist in 0.5. Changed to `map`.