### PR TITLE
Publish Formula and dropterm documentation

### DIFF
--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -79,6 +79,11 @@ making this impossible using normal expressions. However, unlike R, Julia provid
 explicitly indicate when code itself will be manipulated before it's evaluated. By constructing
 a formula using a macro, we're able to provide convenient, R-like syntax and semantics.
 
+```@docs
+Formula
+dropterm
+```
+
 ## The `ModelFrame` and `ModelMatrix` types
 
 The main use of `Formula`s is for fitting statistical models based on tabular


### PR DESCRIPTION
As mentioned https://github.com/JuliaStats/StatsModels.jl/pull/10#issuecomment-271413898. Thanks to @dmbates for suggesting the correct location in the docs for this.

Note: Not skipping CI since the Travis master build is needed to publish the docs using Documenter.