### PR TITLE
Remove some uses of CategoricalArrays, update docs

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -104,18 +104,14 @@ for the base level (which defaults to the first level).
 
 ```julia
 ContrastsMatrix{C <: AbstractContrasts}(contrasts::C, levels::AbstractVector)
-ContrastsMatrix(contrasts::AbstractContrasts,
-                data::Union{CategoricalArray, NullableCategoricalArray})
-ContrastsMatrix(contrasts_matrix::ContrastsMatrix,
-                data::Union{CategoricalArray, NullableCategoricalArray})
+ContrastsMatrix(contrasts::AbstractContrasts, levels::AbstractVector)
+ContrastsMatrix(contrasts_matrix::ContrastsMatrix, levels::AbstractVector)
 ```
 
 # Arguments
 
 * `contrasts::AbstractContrasts`: The contrast coding system to use.
 * `levels::AbstractVector`: The levels to generate contrasts for.
-* `data::[Nullable]CategoricalVector`: If categorical data is provided, levels
-  will be extracted with `levels(data)`.
 * `contrasts_matrix::ContrastsMatrix`: Constructing a `ContrastsMatrix` from
   another will check that the levels match.  This is used, for example, in
   constructing a model matrix from a `ModelFrame` using different data.
@@ -197,7 +193,7 @@ nullify(x::Nullable) = x
 nullify(x) = Nullable(x)
 
 # Making a contrast type T only requires that there be a method for
-# contrasts_matrix(T, v::Union{CategoricalArray, NullableCategoricalArray}).
+# contrasts_matrix(T,  baseind, n) and optionally termnames(T, levels, baseind)
 # The rest is boilerplate.
 for contrastType in [:DummyCoding, :EffectsCoding, :HelmertCoding]
     @eval begin
@@ -241,8 +237,8 @@ type FullDummyCoding <: AbstractContrasts
 # Dummy contrasts have no base level (since all levels produce a column)
 end
 
-ContrastsMatrix{T}(C::FullDummyCoding, lvls::Vector{T}) =
-    ContrastsMatrix(eye(Float64, length(lvls)), lvls, lvls, C)
+ContrastsMatrix{T}(C::FullDummyCoding, levels::Vector{T}) =
+    ContrastsMatrix(eye(Float64, length(levels)), levels, levels, C)
 
 "Promote contrasts matrix to full rank version"
 Base.convert(::Type{ContrastsMatrix{FullDummyCoding}}, C::ContrastsMatrix) =

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -141,14 +141,10 @@ function null_omit(df::DataTable)
     df[cc,:], cc
 end
 
-_droplevels!(x::Any) = x
-_droplevels!(x::Union{CategoricalArray, NullableCategoricalArray}) = droplevels!(x)
-
 function ModelFrame(trms::Terms, d::AbstractDataTable;
                     contrasts::Dict = Dict())
     df, msng = null_omit(DataTable(map(x -> d[x], trms.eterms)))
     names!(df, convert(Vector{Symbol}, map(string, trms.eterms)))
-    for c in eachcol(df) _droplevels!(c[2]) end
 
     evaledContrasts = evalcontrasts(df, contrasts)
 
@@ -194,8 +190,7 @@ end
     termnames(term::Symbol, col)
 Returns a vector of strings with the names of the coefficients
 associated with a term.  If the column corresponding to the term
-is not a `CategoricalArray` or `NullableCategoricalArray`,
-a one-element vector is returned.
+is not categorical, a one-element vector is returned.
 """
 termnames(term::Symbol, col) = [string(term)]
 function termnames(term::Symbol, mf::ModelFrame; non_redundant::Bool = false)

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -42,7 +42,8 @@ modelmat_cols{T<:AbstractFloatMatrix, V<:AbstractRealVector}(::Type{T}, v::V) =
 # FIXME: this inefficient method should not be needed, cf. JuliaLang/julia#18264
 modelmat_cols{T<:AbstractFloatMatrix, V<:NullableRealVector}(::Type{T}, v::V) =
     convert(T, Matrix(reshape(v, length(v), 1)))
-modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::Union{CategoricalVector, NullableCategoricalVector}) =
+# Categorical column, does not make sense to convert to float
+modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector) =
     modelmat_cols(T, reshape(v, length(v), 1))
 
 # All non-real columns are considered as categorical


### PR DESCRIPTION
The first commit fixes docs which were not updated by https://github.com/JuliaStats/StatsModels.jl/pull/13.

The second one removes special cases for `CategoricalArray` which are no longer really needed.