### PR TITLE
WIP: First steps in defining a common interface for Tables/Frames

### DIFF
--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -14,7 +14,7 @@ fields with possibly heterogeneous types.  One of the primary goals of
 `StatsModels` is to make it simpler to transform tabular data into matrix format
 suitable for statistical modeling.
 
-At the moment, "tabular data" means an `AbstractDataTable`.  Ultimately, the
+At the moment, "tabular data" means an `Table`.  Ultimately, the
 goal is to support any tabular data format that adheres to a minimal API,
 **regardless of backend**.
 
@@ -88,7 +88,7 @@ dropterm
 
 The main use of `Formula`s is for fitting statistical models based on tabular
 data.  From the user's perspective, this is done by `fit` methods that take a
-`Formula` and a `DataTable` instead of numeric matrices.
+`Formula` and a `Table` instead of numeric matrices.
 
 Internally, this is accomplished in three stages:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,5 +21,6 @@ developers when dealing with statistical models and tabular data.
     * `RegressionModel`
 
 Much of this package was formerly part
-of [`DataTables`](https://www.github.com/JuliaStats/DataTables.jl)
+of [`DataTables`](https://www.github.com/JuliaStats/DataTables.jl)/
+[`DataFrames`](https://www.github.com/JuliaStats/DataFrames.jl)
 and [`StatsBase`](https://www.github.com/JuliaStats/StatsBase.jl).

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -3,10 +3,12 @@ __precompile__(true)
 module StatsModels
 
 using Compat
-using DataTables
+using TableBase
+using TableBase: Table
+# using DataTables
 using StatsBase
-using NullableArrays
-using CategoricalArrays
+# using NullableArrays
+# using CategoricalArrays
 
 
 export @formula,
@@ -23,6 +25,10 @@ export @formula,
        coefnames,
        dropterm,
        setcontrasts!
+
+# TEMPORARY DEFINITIONS
+const AbstractCategoricalVector = Any
+
 
 map(include,
     [

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -59,7 +59,7 @@ modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector, contrast::Co
 
 
 function modelmat_cols{T<:AbstractFloatMatrix}(::Type{T},
-                                               v::Union{CategoricalVector, NullableCategoricalVector},
+                                               v::AbstractCategoricalVector,
                                                contrast::ContrastsMatrix)
     ## make sure the levels of the contrast matrix and the categorical data
     ## are the same by constructing a re-indexing vector. Indexing into

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -31,23 +31,23 @@ macro delegate(source, targets)
     return result
 end
 
-# Wrappers for DataTableStatisticalModel and DataTableRegressionModel
-immutable DataTableStatisticalModel{M,T} <: StatisticalModel
+# Wrappers for TableStatisticalModel and TableRegressionModel
+immutable TableStatisticalModel{M,T} <: StatisticalModel
     model::M
     mf::ModelFrame
     mm::ModelMatrix{T}
 end
 
-immutable DataTableRegressionModel{M,T} <: RegressionModel
+immutable TableRegressionModel{M,T} <: RegressionModel
     model::M
     mf::ModelFrame
     mm::ModelMatrix{T}
 end
 
-for (modeltype, dfmodeltype) in ((:StatisticalModel, DataTableStatisticalModel),
-                                 (:RegressionModel, DataTableRegressionModel))
+for (modeltype, dfmodeltype) in ((:StatisticalModel, TableStatisticalModel),
+                                 (:RegressionModel, TableRegressionModel))
     @eval begin
-        function StatsBase.fit{T<:$modeltype}(::Type{T}, f::Formula, df::AbstractDataTable,
+        function StatsBase.fit{T<:$modeltype}(::Type{T}, f::Formula, df::Table,
                                               args...; contrasts::Dict = Dict(), kwargs...)
             mf = ModelFrame(f, df, contrasts=contrasts)
             mm = ModelMatrix(mf)
@@ -58,24 +58,24 @@ for (modeltype, dfmodeltype) in ((:StatisticalModel, DataTableStatisticalModel),
 end
 
 # Delegate functions from StatsBase that use our new types
-typealias DataTableModels @compat(Union{DataTableStatisticalModel, DataTableRegressionModel})
-@delegate DataTableModels.model [StatsBase.coef, StatsBase.confint,
+typealias TableModels @compat(Union{TableStatisticalModel, TableRegressionModel})
+@delegate TableModels.model [StatsBase.coef, StatsBase.confint,
                                  StatsBase.deviance, StatsBase.nulldeviance,
                                  StatsBase.loglikelihood, StatsBase.nullloglikelihood,
                                  StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
                                  StatsBase.stderr, StatsBase.vcov]
-@delegate DataTableRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
+@delegate TableRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
                                           StatsBase.predict, StatsBase.predict!]
 # Need to define these manually because of ambiguity using @delegate
-StatsBase.r2(mm::DataTableRegressionModel) = r2(mm.model)
-StatsBase.adjr2(mm::DataTableRegressionModel) = adjr2(mm.model)
-StatsBase.r2(mm::DataTableRegressionModel, variant::Symbol) = r2(mm.model, variant)
-StatsBase.adjr2(mm::DataTableRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
+StatsBase.r2(mm::TableRegressionModel) = r2(mm.model)
+StatsBase.adjr2(mm::TableRegressionModel) = adjr2(mm.model)
+StatsBase.r2(mm::TableRegressionModel, variant::Symbol) = r2(mm.model, variant)
+StatsBase.adjr2(mm::TableRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
 
 # Predict function that takes data frame as predictor instead of matrix
-function StatsBase.predict(mm::DataTableRegressionModel, df::AbstractDataTable; kwargs...)
+function StatsBase.predict(mm::TableRegressionModel, df::Table; kwargs...)
     # copy terms, removing outcome if present (ModelFrame will complain if a
-    # term is not found in the DataTable and we don't want to remove elements with missing y)
+    # term is not found in the Table and we don't want to remove elements with missing y)
     newTerms = dropresponse!(mm.mf.terms)
     # create new model frame/matrix
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
@@ -89,7 +89,7 @@ end
 
 
 # coeftable implementation
-function StatsBase.coeftable(model::DataTableModels)
+function StatsBase.coeftable(model::TableModels)
     ct = coeftable(model.model)
     cfnames = coefnames(model.mf)
     if length(ct.rownms) == length(cfnames)
@@ -99,7 +99,7 @@ function StatsBase.coeftable(model::DataTableModels)
 end
 
 # show function that delegates to coeftable
-function Base.show(io::IO, model::DataTableModels)
+function Base.show(io::IO, model::TableModels)
     try
         ct = coeftable(model)
         println(io, "$(typeof(model))")


### PR DESCRIPTION
There is almost nothing here yet. Just wanted to open the PR such that we have a place to discuss details of #14. This will require a new package with the common interface. So far I've named it `TableBase`. Both `DataFrames` and `DataTables` should then become subtypes of this new `Table` and some subset of the functions in the two packages should be defined as erroring methods in `TableBase` and overloaded in `DataFrames` and `DataTables`.