### PR TITLE
hash and equality for ContrastsMatrix types

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -89,6 +89,17 @@ type ContrastsMatrix{C <: AbstractContrasts, T}
     contrasts::C
 end
 
+# only check equality of matrix, termnames, and levels, and that the type is the
+# same for the contrasts (values are irrelevant).  This ensures that the two
+# will behave identically in creating modelmatrix columns
+Base.:(==){C<:AbstractContrasts,T}(a::ContrastsMatrix{C,T}, b::ContrastsMatrix{C,T}) =
+    a.matrix == b.matrix &&
+    a.termnames == b.termnames &&
+    a.levels == b.levels
+
+Base.hash{C}(a::ContrastsMatrix{C}, h::UInt) =
+    hash(C, hash(a.matrix, hash(a.termnames, hash(a.levels, h))))
+
 """
 An instantiation of a contrast coding system for particular levels
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -5,7 +5,7 @@ using DataTables
 using CategoricalArrays
 using StatsModels
 
-import StatsModels: ContrastsMatrix
+using StatsModels: ContrastsMatrix
 
 d = DataTable(x = CategoricalVector([:a, :b, :c, :a, :a, :b]))
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -5,10 +5,35 @@ using DataTables
 using CategoricalArrays
 using StatsModels
 
+import StatsModels: ContrastsMatrix
 
 d = DataTable(x = CategoricalVector([:a, :b, :c, :a, :a, :b]))
 
 mf = ModelFrame(Formula(nothing, :x), d)
+
+## testing equality of ContrastsMatrix
+should_equal = [ContrastsMatrix(DummyCoding(), [:a, :b, :c]),
+                ContrastsMatrix(DummyCoding(base=:a), [:a, :b, :c]),
+                ContrastsMatrix(DummyCoding(base=:a, levels=[:a, :b, :c]), [:a, :b, :c]),
+                ContrastsMatrix(DummyCoding(levels=[:a, :b, :c]), [:a, :b, :c])]
+
+for c in should_equal
+    @test mf.contrasts[:x] == c
+    @test hash(mf.contrasts[:x]) == hash(c)
+end
+
+should_not_equal = [ContrastsMatrix(EffectsCoding(), [:a, :b, :c]),
+                    ContrastsMatrix(DummyCoding(), [:b, :c]),
+                    ContrastsMatrix(DummyCoding(), [:b, :c, :a]),
+                    ContrastsMatrix(DummyCoding(), [:b, :c, :a]),
+                    ContrastsMatrix(DummyCoding(), [:b, :c, :a]),
+                    ContrastsMatrix(DummyCoding(base=:b), [:a, :b, :c]),
+                    ContrastsMatrix(DummyCoding(base=:a, levels=[:b, :a, :c]), [:a, :b, :c])]
+
+for c in should_not_equal
+    @test mf.contrasts[:x] != c
+end
+
 
 # Dummy coded contrasts by default:
 @test ModelMatrix(mf).m == [1  0  0


### PR DESCRIPTION
Allows ContrastsMatrices to be compared (and used as keys in dicts etc.)