### PR TITLE
Add model_response methods

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,6 @@
 julia 0.5
 DataTables
+Distributions
 CategoricalArrays 0.0.6
 NullableArrays 0.0.10
 StatsBase 0.11.1

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -4,6 +4,7 @@ module StatsModels
 
 using Compat
 using DataTables
+using Distributions
 using StatsBase
 using NullableArrays
 using CategoricalArrays

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -98,7 +98,7 @@ function droprandomeffects(trms::Terms)
     if !any(retrms)  # return trms unchanged
         trms
     elseif all(retrms) && !trms.response   # return an empty Terms object
-        Terms(Any[],Any[],Array(Bool, (0,0)),Array(Bool, (0,0)), Int[], false, trms.intercept)
+        Terms(Any[],Any[],Array{Bool}((0,0)),Array{Bool}((0,0)), Int[], false, trms.intercept)
     else
         # the rows of `trms.factors` correspond to `eterms`, the columns to `terms`
         # After dropping random-effects terms we drop any eterms whose rows are all false


### PR DESCRIPTION
- add `model_response` methods for `Bernoulli` distribution
- also cleaned up deprecated `Array` call signatures in `droprandomeffects`

Fixes #27.