### PR TITLE
Move back to DataFrames and port from Nullable to Missings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 DataFrames 0.11
-CategoricalArrays 0.2.0
-Nulls
+CategoricalArrays 0.3.0
+Missings
 StatsBase 0.11.1
 Compat 0.9.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
-DataTables
+DataFrames
 CategoricalArrays 0.0.6
 NullableArrays 0.0.10
 StatsBase 0.11.1

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
-julia 0.5
-DataFrames
-CategoricalArrays 0.0.6
-NullableArrays 0.0.10
+julia 0.6
+DataFrames 0.11
+CategoricalArrays 0.2.0
+Nulls
 StatsBase 0.11.1
 Compat 0.9.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
+    - release-0.6
 
 notifications:
   - provider: Email

--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -14,7 +14,7 @@ fields with possibly heterogeneous types.  One of the primary goals of
 `StatsModels` is to make it simpler to transform tabular data into matrix format
 suitable for statistical modeling.
 
-At the moment, "tabular data" means an `AbstractDataTable`.  Ultimately, the
+At the moment, "tabular data" means an `AbstractDataFrame`.  Ultimately, the
 goal is to support any tabular data format that adheres to a minimal API,
 **regardless of backend**.
 
@@ -88,7 +88,7 @@ dropterm
 
 The main use of `Formula`s is for fitting statistical models based on tabular
 data.  From the user's perspective, this is done by `fit` methods that take a
-`Formula` and a `DataTable` instead of numeric matrices.
+`Formula` and a `DataFrame` instead of numeric matrices.
 
 Internally, this is accomplished in three stages:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -21,5 +21,5 @@ developers when dealing with statistical models and tabular data.
     * `RegressionModel`
 
 Much of this package was formerly part
-of [`DataTables`](https://www.github.com/JuliaStats/DataTables.jl)
+of [`DataFrames`](https://www.github.com/JuliaStats/DataFrames.jl)
 and [`StatsBase`](https://www.github.com/JuliaStats/StatsBase.jl).

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -5,7 +5,7 @@ module StatsModels
 using Compat
 using DataFrames
 using StatsBase
-using Nulls
+using Missings
 using CategoricalArrays
 
 

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -3,7 +3,7 @@ __precompile__(true)
 module StatsModels
 
 using Compat
-using DataTables
+using DataFrames
 using StatsBase
 using NullableArrays
 using CategoricalArrays

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -5,7 +5,7 @@ module StatsModels
 using Compat
 using DataFrames
 using StatsBase
-using NullableArrays
+using Nulls
 using CategoricalArrays
 
 

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -54,7 +54,7 @@ type ModelFrame
     contrasts::Dict{Symbol, ContrastsMatrix}
 end
 
-is_categorical(::AbstractArray{<:Union{Null, Real}}) = false
+is_categorical(::AbstractArray{<:Union{Missing, Real}}) = false
 is_categorical(::AbstractArray) = true
 
 ## Check for non-redundancy of columns.  For instance, if x is a factor with two
@@ -103,12 +103,12 @@ end
 const DEFAULT_CONTRASTS = DummyCoding
 
 _unique(x::AbstractCategoricalArray) = unique(x)
-_unique(x::AbstractCategoricalArray{T}) where {T>:Null} =
-    convert(Array{Nulls.T(T)}, filter!(!isnull, unique(x)))
+_unique(x::AbstractCategoricalArray{T}) where {T>:Missing} =
+    convert(Array{Missings.T(T)}, filter!(!ismissing, unique(x)))
 
 function _unique(x::AbstractArray{T}) where T
-    levs = T >: Null ?
-           convert(Array{Nulls.T(T)}, filter!(!isnull, unique(x))) :
+    levs = T >: Missing ?
+           convert(Array{Missings.T(T)}, filter!(!ismissing, unique(x))) :
            unique(x)
     try; sort!(levs); end
     return levs
@@ -131,7 +131,7 @@ function evalcontrasts(df::AbstractDataFrame, contrasts::Dict = Dict())
 end
 
 ## Default NULL handler.  Others can be added as keyword arguments
-function null_omit(df::DataFrame)
+function missing_omit(df::DataFrame)
     cc = completecases(df)
     df[cc,:], cc
 end
@@ -141,7 +141,7 @@ _droplevels!(x::AbstractCategoricalArray) = droplevels!(x)
 
 function ModelFrame(trms::Terms, d::AbstractDataFrame;
                     contrasts::Dict = Dict())
-    df, msng = null_omit(DataFrame(map(x -> d[x], trms.eterms)))
+    df, msng = missing_omit(DataFrame(map(x -> d[x], trms.eterms)))
     names!(df, convert(Vector{Symbol}, map(string, trms.eterms)))
 
     evaledContrasts = evalcontrasts(df, contrasts)

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -1,5 +1,5 @@
 """
-Wrapper which combines Formula (Terms) and an AbstractDataTable
+Wrapper which combines Formula (Terms) and an AbstractDataFrame
 
 This wrapper encapsulates all the information that's required to transform data
 of the same structure as the wrapped data frame into a model matrix.  This goes
@@ -13,19 +13,19 @@ then creates the necessary contrasts matrices and stores the results.
 # Constructors
 
 ```julia
-ModelFrame(f::Formula, df::AbstractDataTable; contrasts::Dict = Dict())
-ModelFrame(ex::Expr, d::AbstractDataTable; contrasts::Dict = Dict())
-ModelFrame(terms::Terms, df::AbstractDataTable; contrasts::Dict = Dict())
+ModelFrame(f::Formula, df::AbstractDataFrame; contrasts::Dict = Dict())
+ModelFrame(ex::Expr, d::AbstractDataFrame; contrasts::Dict = Dict())
+ModelFrame(terms::Terms, df::AbstractDataFrame; contrasts::Dict = Dict())
 # Inner constructors:
-ModelFrame(df::AbstractDataTable, terms::Terms, missing::BitArray)
-ModelFrame(df::AbstractDataTable, terms::Terms, missing::BitArray, contrasts::Dict{Symbol, ContrastsMatrix})
+ModelFrame(df::AbstractDataFrame, terms::Terms, missing::BitArray)
+ModelFrame(df::AbstractDataFrame, terms::Terms, missing::BitArray, contrasts::Dict{Symbol, ContrastsMatrix})
 ```
 
 # Arguments
 
 * `f::Formula`: Formula whose left hand side is the *response* and right hand
   side are the *predictors*.
-* `df::AbstractDataTable`: The data being modeled.  This is used at this stage
+* `df::AbstractDataFrame`: The data being modeled.  This is used at this stage
   to determine which variables are categorical, and otherwise held for
   [`ModelMatrix`](@ref).
 * `contrasts::Dict`: An optional Dict of contrast codings for each categorical
@@ -41,13 +41,13 @@ ModelFrame(df::AbstractDataTable, terms::Terms, missing::BitArray, contrasts::Di
 # Examples
 
 ```julia
-julia> df = DataTable(x = 1:4, y = 5:9)
+julia> df = DataFrame(x = 1:4, y = 5:9)
 julia> mf = ModelFrame(y ~ 1 + x, df)
 ```
 
 """
 type ModelFrame
-    df::AbstractDataTable
+    df::AbstractDataFrame
     terms::Terms
     msng::BitArray
     ## mapping from df keys to contrasts matrices
@@ -69,7 +69,7 @@ is_categorical(::AbstractArray) = true
 ##
 ## This modifies the Terms, setting `trms.is_non_redundant = true` for all non-
 ## redundant evaluation terms.
-function check_non_redundancy!(trms::Terms, df::AbstractDataTable)
+function check_non_redundancy!(trms::Terms, df::AbstractDataFrame)
 
     (n_eterms, n_terms) = size(trms.factors)
 
@@ -123,7 +123,7 @@ end
 ## Combine actual DF columns and contrast types if necessary to compute the
 ## actual contrasts matrices, levels, and term names (using DummyCoding
 ## as the default)
-function evalcontrasts(df::AbstractDataTable, contrasts::Dict = Dict())
+function evalcontrasts(df::AbstractDataFrame, contrasts::Dict = Dict())
     evaledContrasts = Dict()
     for (term, col) in eachcol(df)
         is_categorical(col) || continue
@@ -136,14 +136,17 @@ function evalcontrasts(df::AbstractDataTable, contrasts::Dict = Dict())
 end
 
 ## Default NULL handler.  Others can be added as keyword arguments
-function null_omit(df::DataTable)
+function null_omit(df::DataFrame)
     cc = completecases(df)
     df[cc,:], cc
 end
 
-function ModelFrame(trms::Terms, d::AbstractDataTable;
+_droplevels!(x::Any) = x
+_droplevels!(x::Union{CategoricalArray, NullableCategoricalArray}) = droplevels!(x)
+
+function ModelFrame(trms::Terms, d::AbstractDataFrame;
                     contrasts::Dict = Dict())
-    df, msng = null_omit(DataTable(map(x -> d[x], trms.eterms)))
+    df, msng = null_omit(DataFrame(map(x -> d[x], trms.eterms)))
     names!(df, convert(Vector{Symbol}, map(string, trms.eterms)))
 
     evaledContrasts = evalcontrasts(df, contrasts)
@@ -154,9 +157,9 @@ function ModelFrame(trms::Terms, d::AbstractDataTable;
     ModelFrame(df, trms, msng, evaledContrasts)
 end
 
-ModelFrame(df::AbstractDataTable, term::Terms, msng::BitArray) = ModelFrame(df, term, msng, evalcontrasts(df))
-ModelFrame(f::Formula, d::AbstractDataTable; kwargs...) = ModelFrame(Terms(f), d; kwargs...)
-ModelFrame(ex::Expr, d::AbstractDataTable; kwargs...) = ModelFrame(Formula(ex), d; kwargs...)
+ModelFrame(df::AbstractDataFrame, term::Terms, msng::BitArray) = ModelFrame(df, term, msng, evalcontrasts(df))
+ModelFrame(f::Formula, d::AbstractDataFrame; kwargs...) = ModelFrame(Terms(f), d; kwargs...)
+ModelFrame(ex::Expr, d::AbstractDataFrame; kwargs...) = ModelFrame(Formula(ex), d; kwargs...)
 
 """
     setcontrasts!(mf::ModelFrame, new_contrasts::Dict)

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -35,7 +35,7 @@ function modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, name::Symbol, mf::Mode
     end
 end
 
-modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector{<:Union{Null, Real}}) =
+modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector{<:Union{Missing, Real}}) =
     convert(T, reshape(v, length(v), 1))
 # Categorical column, does not make sense to convert to float
 modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector) =

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -1,7 +1,5 @@
 
 typealias AbstractFloatMatrix{T<:AbstractFloat} AbstractMatrix{T}
-typealias AbstractRealVector{T<:Real} AbstractVector{T}
-typealias NullableRealVector{T<:NullableReal} AbstractVector{T}
 
 """
 Convert a `ModelFrame` into a numeric matrix suitable for modeling
@@ -37,11 +35,8 @@ function modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, name::Symbol, mf::Mode
     end
 end
 
-modelmat_cols{T<:AbstractFloatMatrix, V<:AbstractRealVector}(::Type{T}, v::V) =
+modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector{<:Union{Null, Real}}) =
     convert(T, reshape(v, length(v), 1))
-# FIXME: this inefficient method should not be needed, cf. JuliaLang/julia#18264
-modelmat_cols{T<:AbstractFloatMatrix, V<:NullableRealVector}(::Type{T}, v::V) =
-    convert(T, Matrix(reshape(v, length(v), 1)))
 # Categorical column, does not make sense to convert to float
 modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector) =
     modelmat_cols(T, reshape(v, length(v), 1))
@@ -59,7 +54,7 @@ modelmat_cols{T<:AbstractFloatMatrix}(::Type{T}, v::AbstractVector, contrast::Co
 
 
 function modelmat_cols{T<:AbstractFloatMatrix}(::Type{T},
-                                               v::Union{CategoricalVector, NullableCategoricalVector},
+                                               v::AbstractCategoricalVector,
                                                contrast::ContrastsMatrix)
     ## make sure the levels of the contrast matrix and the categorical data
     ## are the same by constructing a re-indexing vector. Indexing into

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -31,23 +31,23 @@ macro delegate(source, targets)
     return result
 end
 
-# Wrappers for DataTableStatisticalModel and DataTableRegressionModel
-immutable DataTableStatisticalModel{M,T} <: StatisticalModel
+# Wrappers for DataFrameStatisticalModel and DataFrameRegressionModel
+immutable DataFrameStatisticalModel{M,T} <: StatisticalModel
     model::M
     mf::ModelFrame
     mm::ModelMatrix{T}
 end
 
-immutable DataTableRegressionModel{M,T} <: RegressionModel
+immutable DataFrameRegressionModel{M,T} <: RegressionModel
     model::M
     mf::ModelFrame
     mm::ModelMatrix{T}
 end
 
-for (modeltype, dfmodeltype) in ((:StatisticalModel, DataTableStatisticalModel),
-                                 (:RegressionModel, DataTableRegressionModel))
+for (modeltype, dfmodeltype) in ((:StatisticalModel, DataFrameStatisticalModel),
+                                 (:RegressionModel, DataFrameRegressionModel))
     @eval begin
-        function StatsBase.fit{T<:$modeltype}(::Type{T}, f::Formula, df::AbstractDataTable,
+        function StatsBase.fit{T<:$modeltype}(::Type{T}, f::Formula, df::AbstractDataFrame,
                                               args...; contrasts::Dict = Dict(), kwargs...)
             mf = ModelFrame(f, df, contrasts=contrasts)
             mm = ModelMatrix(mf)
@@ -58,24 +58,24 @@ for (modeltype, dfmodeltype) in ((:StatisticalModel, DataTableStatisticalModel),
 end
 
 # Delegate functions from StatsBase that use our new types
-typealias DataTableModels @compat(Union{DataTableStatisticalModel, DataTableRegressionModel})
-@delegate DataTableModels.model [StatsBase.coef, StatsBase.confint,
+typealias DataFrameModels @compat(Union{DataFrameStatisticalModel, DataFrameRegressionModel})
+@delegate DataFrameModels.model [StatsBase.coef, StatsBase.confint,
                                  StatsBase.deviance, StatsBase.nulldeviance,
                                  StatsBase.loglikelihood, StatsBase.nullloglikelihood,
                                  StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
                                  StatsBase.stderr, StatsBase.vcov]
-@delegate DataTableRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
+@delegate DataFrameRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
                                           StatsBase.predict, StatsBase.predict!]
 # Need to define these manually because of ambiguity using @delegate
-StatsBase.r2(mm::DataTableRegressionModel) = r2(mm.model)
-StatsBase.adjr2(mm::DataTableRegressionModel) = adjr2(mm.model)
-StatsBase.r2(mm::DataTableRegressionModel, variant::Symbol) = r2(mm.model, variant)
-StatsBase.adjr2(mm::DataTableRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
+StatsBase.r2(mm::DataFrameRegressionModel) = r2(mm.model)
+StatsBase.adjr2(mm::DataFrameRegressionModel) = adjr2(mm.model)
+StatsBase.r2(mm::DataFrameRegressionModel, variant::Symbol) = r2(mm.model, variant)
+StatsBase.adjr2(mm::DataFrameRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
 
 # Predict function that takes data frame as predictor instead of matrix
-function StatsBase.predict(mm::DataTableRegressionModel, df::AbstractDataTable; kwargs...)
+function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; kwargs...)
     # copy terms, removing outcome if present (ModelFrame will complain if a
-    # term is not found in the DataTable and we don't want to remove elements with missing y)
+    # term is not found in the DataFrame and we don't want to remove elements with missing y)
     newTerms = dropresponse!(mm.mf.terms)
     # create new model frame/matrix
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
@@ -89,7 +89,7 @@ end
 
 
 # coeftable implementation
-function StatsBase.coeftable(model::DataTableModels)
+function StatsBase.coeftable(model::DataFrameModels)
     ct = coeftable(model.model)
     cfnames = coefnames(model.mf)
     if length(ct.rownms) == length(cfnames)
@@ -99,7 +99,7 @@ function StatsBase.coeftable(model::DataTableModels)
 end
 
 # show function that delegates to coeftable
-function Base.show(io::IO, model::DataTableModels)
+function Base.show(io::IO, model::DataFrameModels)
     try
         ct = coeftable(model)
         println(io, "$(typeof(model))")

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -81,7 +81,7 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; 
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
     newX = ModelMatrix(mf).m
     yp = predict(mm, newX; kwargs...)
-    out = nulls(eltype(yp), size(df, 1))
+    out = missings(eltype(yp), size(df, 1))
     out[mf.msng] = yp
     return(out)
 end

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -81,7 +81,7 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; 
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
     newX = ModelMatrix(mf).m
     yp = predict(mm, newX; kwargs...)
-    out = NullableArray(eltype(yp), size(df, 1))
+    out = nulls(eltype(yp), size(df, 1))
     out[mf.msng] = yp
     return(out)
 end

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -3,11 +3,11 @@ module TestContrasts
 using Base.Test
 using DataFrames
 using StatsModels
-using Nulls
+using Missings
 
 using StatsModels: ContrastsMatrix
 
-d = DataFrame(x = CategoricalVector{Union{Null, Symbol}}([:a, :b, :c, :a, :a, :b]))
+d = DataFrame(x = CategoricalVector{Union{Missing, Symbol}}([:a, :b, :c, :a, :a, :b]))
 
 mf = ModelFrame(Formula(nothing, :x), d)
 
@@ -102,7 +102,7 @@ setcontrasts!(mf, x = HelmertCoding())
 @test_throws ArgumentError setcontrasts!(mf, x = EffectsCoding(levels = ["a", "b", "c"]))
 
 # Missing data is handled gracefully, dropping columns when a level is lost
-d[3, :x] = null
+d[3, :x] = missing
 mf_missing = ModelFrame(Formula(nothing, :x), d, contrasts = Dict(:x => EffectsCoding()))
 @test ModelMatrix(mf_missing).m == [1 -1
                                     1  1

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -1,13 +1,12 @@
 module TestContrasts
 
 using Base.Test
-using DataTables
-using CategoricalArrays
+using DataFrames
 using StatsModels
 
 using StatsModels: ContrastsMatrix
 
-d = DataTable(x = CategoricalVector([:a, :b, :c, :a, :a, :b]))
+d = DataFrame(x = CategoricalVector([:a, :b, :c, :a, :a, :b]))
 
 mf = ModelFrame(Formula(nothing, :x), d)
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -3,10 +3,11 @@ module TestContrasts
 using Base.Test
 using DataFrames
 using StatsModels
+using Nulls
 
 using StatsModels: ContrastsMatrix
 
-d = DataFrame(x = CategoricalVector([:a, :b, :c, :a, :a, :b]))
+d = DataFrame(x = CategoricalVector{Union{Null, Symbol}}([:a, :b, :c, :a, :a, :b]))
 
 mf = ModelFrame(Formula(nothing, :x), d)
 
@@ -101,7 +102,7 @@ setcontrasts!(mf, x = HelmertCoding())
 @test_throws ArgumentError setcontrasts!(mf, x = EffectsCoding(levels = ["a", "b", "c"]))
 
 # Missing data is handled gracefully, dropping columns when a level is lost
-d[3, :x] = Nullable()
+d[3, :x] = null
 mf_missing = ModelFrame(Formula(nothing, :x), d, contrasts = Dict(:x => EffectsCoding()))
 @test ModelMatrix(mf_missing).m == [1 -1
                                     1  1

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -6,7 +6,7 @@ using Compat
 
 # TODO:
 # - grouped variables in formulas with interactions
-# - is it fast?  Can expand() handle DataTables?
+# - is it fast?  Can expand() handle DataFrames?
 # - deal with intercepts
 # - implement ^2 for datavector's
 # - support more transformations with I()?

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -2,11 +2,10 @@ module TestModelMatrix
 
 using Base.Test
 using StatsModels
-using DataTables
+using DataFrames
 using Compat
-using CategoricalArrays
 
-# for testing while DataTables still exports these:
+# for testing while DataFrames still exports these:
 import StatsModels: @formula, Formula, ModelMatrix, ModelFrame, DummyCoding, EffectsCoding, HelmertCoding, ContrastsCoding, setcontrasts!, coefnames
 
 
@@ -14,7 +13,7 @@ import StatsModels: @formula, Formula, ModelMatrix, ModelFrame, DummyCoding, Eff
 
 sparsetype = SparseMatrixCSC{Float64,Int}
 
-d = DataTable()
+d = DataFrame()
 d[:y] = [1:4;]
 d[:x1] = [5:8;]
 d[:x2] = [9:12;]
@@ -51,59 +50,59 @@ mm = ModelMatrix(mf)
 @test coefnames(mf)[2:end] == ["x1p: 6", "x1p: 7", "x1p: 8"]
 @test mm.m == ModelMatrix{sparsetype}(mf).m
 
-#test_group("create a design matrix from interactions from two DataTables")
+#test_group("create a design matrix from interactions from two DataFrames")
 ## this was removed in commit dead4562506badd7e84a2367086f5753fa49bb6a
 
-## b = DataTable()
+## b = DataFrame()
 ## b["x2"] = DataVector(x2)
 ## df = interaction_design_matrix(a,b)
 ## @test df[:,1] == DataVector([0, 10., 0, 0])
 ## @test df[:,2] == DataVector([0, 0, 11., 0])
 ## @test df[:,3] == DataVector([0, 0, 0, 12.])
 
-#test_group("expanding an singleton expression/symbol into a DataTable")
+#test_group("expanding an singleton expression/symbol into a DataFrame")
 ## generalized expand was dropped, too
 ## df = deepcopy(d)
 ## r = expand(:x2, df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test r[:,1] == DataVector([9,10,11,12])  # TODO: test float vs int return
 
 ## df = deepcopy(d)
 ## ex = :(log(x2))
 ## r = expand(ex, df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test r[:,1] == DataVector(log([9,10,11,12]))
 
 # ex = :(x1 & x2)
 # r = expand(ex, df)
-# @test isa(r, DataTable)
+# @test isa(r, DataFrame)
 # @test ncol(r) == 1
 # @test r[:,1] == DataArray([45, 60, 77, 96])
 
 ## r = expand(:(x1 + x2), df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test ncol(r) == 2
 ## @test r[:,1] == DataVector(df["x1"])
 ## @test r[:,2] == DataVector(df["x2"])
 
 ## df["x1"] = CategoricalArray(x1)
 ## r = expand(:x1, df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test ncol(r) == 3
-## @test r == expand(CategoricalArray(x1), "x1", DataTable())
+## @test r == expand(CategoricalArray(x1), "x1", DataFrame())
 
 ## r = expand(:(x1 + x2), df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test ncol(r) == 4
-## @test r[:,1:3] == expand(CategoricalArray(x1), "x1", DataTable())
+## @test r[:,1:3] == expand(CategoricalArray(x1), "x1", DataFrame())
 ## @test r[:,4] == DataVector(df["x2"])
 
 ## df["x2"] = CategoricalArray(x2)
 ## r = expand(:(x1 + x2), df)
-## @test isa(r, DataTable)
+## @test isa(r, DataFrame)
 ## @test ncol(r) == 6
-## @test r[:,1:3] == expand(CategoricalArray(x1), "x1", DataTable())
-## @test r[:,4:6] == expand(CategoricalArray(x2), "x2", DataTable())
+## @test r[:,1:3] == expand(CategoricalArray(x1), "x1", DataFrame())
+## @test r[:,4:6] == expand(CategoricalArray(x2), "x2", DataFrame())
 
 #test_group("Creating a model matrix using full formulas: y => x1 + x2, etc")
 
@@ -237,7 +236,7 @@ mm = ModelMatrix(mf)
 ##
 ## FAILS: behavior is wrong when no lower-order terms (1+x1+x2+x1&x2...)
 ##
-## df = DataTable(y=1:27,
+## df = DataFrame(y=1:27,
 ##                x1 = CategoricalArray(vec([x for x in 1:3, y in 4:6, z in 7:9])),
 ##                x2 = CategoricalArray(vec([y for x in 1:3, y in 4:6, z in 7:9])),
 ##                x3 = CategoricalArray(vec([z for x in 1:3, y in 4:6, z in 7:9])))
@@ -297,7 +296,7 @@ mm.m == float(model_response(mf))
 
 ## Promote non-redundant categorical terms to full rank
 
-d = DataTable(x = Compat.repeat([:a, :b], outer = 4),
+d = DataFrame(x = Compat.repeat([:a, :b], outer = 4),
               y = Compat.repeat([:c, :d], inner = 2, outer = 2),
               z = Compat.repeat([:e, :f], inner = 4))
 [categorical!(d, name) for name in names(d)]
@@ -435,7 +434,7 @@ mm = ModelMatrix(mf)
 
 
 # Ensure that random effects terms are dropped from coefnames
-df = DataTable(x = [1,2,3], y = [4,5,6])
+df = DataFrame(x = [1,2,3], y = [4,5,6])
 mf = ModelFrame(@formula(y ~ 1 + (1 | x)), df)
 @test coefnames(mf) == ["(Intercept)"]
 
@@ -445,7 +444,7 @@ mf = ModelFrame(@formula(y ~ 0 + (1 | x)), df)
 
 
 # Ensure X is not a view on df column
-df = DataTable(x = [1.0,2.0,3.0], y = [4.0,5.0,6.0])
+df = DataFrame(x = [1.0,2.0,3.0], y = [4.0,5.0,6.0])
 mf = ModelFrame(@formula(y ~ 0 + x), df)
 X = ModelMatrix(mf).m
 X[1] = 0.0

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -294,7 +294,7 @@ mm = ModelMatrix(mf)
 ## Same variable on left and right side
 mf = ModelFrame(@formula(x1 ~ x1), df)
 mm = ModelMatrix(mf)
-mm.m == float(model_response(mf))
+mm.m == model_response(mf)
 
 ## Promote non-redundant categorical terms to full rank
 

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -4,7 +4,7 @@ using Base.Test
 using StatsModels
 using StatsBase
 using DataFrames
-using Nulls
+using Missings
 using Compat
 
 # for testing while DataFrames still exports these:
@@ -182,7 +182,7 @@ mm = ModelMatrix(mf)
 ## @test model_response(mf) == y''     # fails: Int64 vs. Float64
 
 df = deepcopy(d)
-df[:x1] = CategoricalArray{Union{Null, Float64}}(df[:x1])
+df[:x1] = CategoricalArray{Union{Missing, Float64}}(df[:x1])
 
 f = @formula(y ~ x2 + x3 + x3*x2)
 mm = ModelMatrix(ModelFrame(f, df))
@@ -285,7 +285,7 @@ mm_sub = ModelMatrix(mf_sub)
 @test size(mm_sub) == (3,3)
 
 ## Missing data
-d[:x1m] = [5, 6, null, 7]
+d[:x1m] = [5, 6, missing, 7]
 mf = ModelFrame(@formula(y ~ x1m), d)
 mm = ModelMatrix(mf)
 @test mm.m[:, 2] == d[completecases(d), :x1m]

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -1,7 +1,7 @@
 module TestStatsModels
 
 using StatsModels
-using DataTables
+using DataFrames
 using Base.Test
 using Compat
 
@@ -26,7 +26,7 @@ StatsBase.coeftable(mod::DummyMod) =
               0)
 
 ## Test fitting
-d = DataTable()
+d = DataFrame()
 d[:y] = [1:4;]
 d[:x1] = [5:8;]
 d[:x2] = [9:12;]
@@ -47,7 +47,7 @@ StatsBase.predict(mod::DummyMod, newX::Matrix) = newX * mod.beta
 mm = ModelMatrix(ModelFrame(f, d))
 @test predict(m, mm.m) == mm.m * collect(1:4)
 
-## new data from DataTable (via ModelMatrix)
+## new data from DataFrame (via ModelMatrix)
 @test isequal(predict(m, d), NullableArray(predict(m, mm.m)))
 
 d2 = deepcopy(d)

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -29,7 +29,7 @@ StatsBase.coeftable(mod::DummyMod) =
 ## Test fitting
 d = DataFrame()
 d[:y] = [1:4;]
-d[:x1] = Vector{Union{Null, Int}}(5:8)
+d[:x1] = Vector{Union{Missing, Int}}(5:8)
 d[:x2] = [9:12;]
 d[:x3] = [13:16;]
 d[:x4] = [17:20;]
@@ -52,7 +52,7 @@ mm = ModelMatrix(ModelFrame(f, d))
 @test predict(m, d) == predict(m, mm.m)
 
 d2 = deepcopy(d)
-d2[3, :x1] = null
+d2[3, :x1] = missing
 @test length(predict(m, d2)) == 4
 
 ## test copying of names from Terms to CoefTable
@@ -64,7 +64,7 @@ io = IOBuffer()
 show(io, m)
 
 ## with categorical variables
-d[:x1p] = CategoricalArray{Union{Null, Int}}(d[:x1])
+d[:x1p] = CategoricalArray{Union{Missing, Int}}(d[:x1])
 f2 = @formula(y ~ x1p)
 m2 = fit(DummyMod, f2, d)
 
@@ -76,11 +76,11 @@ m2 = fit(DummyMod, f2, d)
 ## predict w/ new data with _extra_ levels (throws an error)
 d3 = deepcopy(d)
 d3[1, :x1] = 0
-d3[:x1p] = CategoricalVector{Union{Null, Int}}(d3[:x1])
+d3[:x1p] = CategoricalVector{Union{Missing, Int}}(d3[:x1])
 @test_throws ArgumentError predict(m2, d3)
 
 ## fit with contrasts specified
-d[:x2p] = CategoricalVector{Union{Null, Int}}(d[:x2])
+d[:x2p] = CategoricalVector{Union{Missing, Int}}(d[:x2])
 f3 = @formula(y ~ x1p + x2p)
 m3 = fit(DummyMod, f3, d)
 fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding()))


### PR DESCRIPTION
Keep Nullable in cases where it's used to represent "software engineer's nulls",
i.e. not missing values in data, since the replacement for that in Base is not yet clear.

It should also be possible to avoid returning a `Union{T, Null}` vector from `predict()` when
the input variables are not nullable by storing that in the type information, but
this is left for later.

Also require Julia 0.6.

----------

The two commits should be merged as the first one does not make sense in isolation. Tests won't pass until a new DataFrames release based on `Union{Null, T}` is tagged (tentatively referred to as 0.10 here).