### PR TITLE
Fix warnings from `Pkg.test` on v0.6.1

### DIFF
--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -93,7 +93,7 @@ function droprandomeffects(trms::Terms)
     if !any(retrms)  # return trms unchanged
         trms
     elseif all(retrms) && !trms.response   # return an empty Terms object
-        Terms(Any[],Any[],Array(Bool, (0,0)),Array(Bool, (0,0)), Int[], false, trms.intercept)
+        Terms(Any[],Any[],Array{Bool}((0,0)),Array{Bool}((0,0)), Int[], false, trms.intercept)
     else
         # the rows of `trms.factors` correspond to `eterms`, the columns to `terms`
         # After dropping random-effects terms we drop any eterms whose rows are all false

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -97,7 +97,7 @@ function droprandomeffects(trms::Terms)
     else
         # the rows of `trms.factors` correspond to `eterms`, the columns to `terms`
         # After dropping random-effects terms we drop any eterms whose rows are all false
-        ckeep = !retrms                 # columns to retain
+        ckeep = .!retrms                 # columns to retain
         facs = trms.factors[:, ckeep]
         rkeep = vec(sum(facs, 2) .> 0)
         Terms(trms.terms[ckeep], trms.eterms[rkeep], facs[rkeep, :],

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -441,7 +441,7 @@ mf = ModelFrame(@formula(y ~ 1 + (1 | x)), df)
 
 mf = ModelFrame(@formula(y ~ 0 + (1 | x)), df)
 @test_throws ErrorException ModelMatrix(mf)
-@test coefnames(mf) == Vector{Compat.UTF8String}()
+@test coefnames(mf) == Vector{String}()
 
 
 # Ensure X is not a view on df column


### PR DESCRIPTION
I extracted these two simple fixes from #28 and #45 which were more complicated and, to some extent, overridden by #33.  They eliminate warnings from `Pkg.test("StatsModels)` in v0.6.1 of Julia.