### PR TITLE
added has_intercept

### DIFF
--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -140,7 +140,9 @@ _droplevels!(x::Any) = x
 _droplevels!(x::AbstractCategoricalArray) = droplevels!(x)
 
 function ModelFrame(trms::Terms, d::AbstractDataFrame;
-                    contrasts::Dict = Dict())
+                    contrasts::Dict = Dict(), intercept::Bool = true)
+    trms = Terms((getfield(trms, fieldname) for fieldname in fieldnames(trms))...)
+    intercept || (trms.intercept = false)
     df, msng = missing_omit(DataFrame(map(x -> d[x], trms.eterms)))
     names!(df, Symbol.(string.(trms.eterms)))
 

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -140,9 +140,7 @@ _droplevels!(x::Any) = x
 _droplevels!(x::AbstractCategoricalArray) = droplevels!(x)
 
 function ModelFrame(trms::Terms, d::AbstractDataFrame;
-                    contrasts::Dict = Dict(), intercept::Bool = true)
-    trms = Terms((getfield(trms, fieldname) for fieldname in fieldnames(trms))...)
-    intercept || (trms.intercept = false)
+                    contrasts::Dict = Dict())
     df, msng = missing_omit(DataFrame(map(x -> d[x], trms.eterms)))
     names!(df, Symbol.(string.(trms.eterms)))
 

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -46,13 +46,16 @@ struct DataFrameRegressionModel{M,T} <: RegressionModel
 end
 
 """
-    supports_intercept(::Any)
+    supports_intercept(::Type)
 
-Defines whether a given model supports intercept. Returns `true`. To specify that a model `T` does not support an intercept, overload this function for the corresponding type: `supports_intercept(::Type{T}) = false`
+Define whether a given model supports intercept. Return `true` by default. To specify 
+that a model type `T` does not support an intercept, overload this function for the 
+corresponding type: `supports_intercept(::Type{T}) = false`
 
-Models that do not support intercept will be fit without one: the intercept term will be removed even if explicitly provided by the user.
+Models that do not support an intercept will be fitted without one: the intercept term 
+will be removed even if explicitly provided by the user.
 """
-supports_intercept(::Any) = true
+supports_intercept(::Type) = true
 
 for (modeltype, dfmodeltype) in ((:StatisticalModel, DataFrameStatisticalModel),
                                  (:RegressionModel, DataFrameRegressionModel))

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -45,12 +45,15 @@ struct DataFrameRegressionModel{M,T} <: RegressionModel
     mm::ModelMatrix{T}
 end
 
+# Overload this function for a specific model type, according to whether it requires an intercept
+has_intercept(::Any) = true
+
 for (modeltype, dfmodeltype) in ((:StatisticalModel, DataFrameStatisticalModel),
                                  (:RegressionModel, DataFrameRegressionModel))
     @eval begin
         function StatsBase.fit(::Type{T}, f::Formula, df::AbstractDataFrame,
                                args...; contrasts::Dict = Dict(), kwargs...) where T<:$modeltype
-            mf = ModelFrame(f, df, contrasts=contrasts)
+            mf = ModelFrame(f, df, contrasts=contrasts, intercept=has_intercept(T))
             mm = ModelMatrix(mf)
             y = model_response(mf)
             $dfmodeltype(fit(T, mm.m, y, args...; kwargs...), mf, mm)

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -96,7 +96,7 @@ struct DummyModNoIntercept <: RegressionModel
     y::Vector
 end
 
-StatsModels.supports_intercept(::Type{DummyModNoIntercept}) = false
+StatsModels.drop_intercept(::Type{DummyModNoIntercept}) = true
 
 ## dumb fit method: just copy the x and y input over
 StatsBase.fit(::Type{DummyModNoIntercept}, x::Matrix, y::Vector) =
@@ -116,6 +116,14 @@ m2 = fit(DummyModNoIntercept, f2, d)
 ct1 = coeftable(m1)
 ct2 = coeftable(m2)
 @test ct1.rownms == ct2.rownms == ["x1", "x2", "x1 & x2"]
+
+f1 = @formula(y ~ 1 + x1p)
+f2 = @formula(y ~ 0 + x1p)
+m1 = fit(DummyModNoIntercept, f1, d)
+m2 = fit(DummyModNoIntercept, f2, d)
+ct1 = coeftable(m1)
+ct2 = coeftable(m2)
+@test ct1.rownms == ct2.rownms == ["x1p: 6", "x1p: 7", "x1p: 8"]
 
 ## Another dummy model type to test fall-through show method
 struct DummyModTwo <: RegressionModel

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -89,6 +89,33 @@ fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding(),
 @test_throws Exception fit(DummyMod, f3, d, contrasts = Dict(:x1p => EffectsCoding(),
                                                              :x2p => 1))
 
+# A dummy RegressionModel type that does not support intercept
+struct DummyModNoIntercept <: RegressionModel
+    beta::Vector{Float64}
+    x::Matrix
+    y::Vector
+end
+
+StatsModels.supports_intercept(::Type{DummyModNoIntercept}) = false
+
+## dumb fit method: just copy the x and y input over
+StatsBase.fit(::Type{DummyModNoIntercept}, x::Matrix, y::Vector) =
+    DummyModNoIntercept(collect(1:size(x, 2)), x, y)
+StatsBase.model_response(mod::DummyModNoIntercept) = mod.y
+## dumb coeftable: just prints the "beta" values
+StatsBase.coeftable(mod::DummyModNoIntercept) =
+    CoefTable(reshape(mod.beta, (size(mod.beta,1), 1)),
+             ["'beta' value"],
+             ["" for n in 1:size(mod.x,2)],
+             0)
+
+f1 = @formula(y ~ 1 + x1 * x2)
+f2 = @formula(y ~ 0 + x1 * x2)
+m1 = fit(DummyModNoIntercept, f1, d)
+m2 = fit(DummyModNoIntercept, f2, d)
+ct1 = coeftable(m1)
+ct2 = coeftable(m2)
+@test ct1.rownms == ct2.rownms == ["x1", "x2", "x1 & x2"]
 
 ## Another dummy model type to test fall-through show method
 struct DummyModTwo <: RegressionModel


### PR DESCRIPTION
I've added the option of manually specifying that a specific model doesn't want the intercept column (application case: Cox model, where the intercept column is meaningless and should be excluded, see discussion in [#2](https://github.com/ararslan/Survival.jl/pull/2) ). This happens with a keyword `intercept = true` to `ModelFrame`. When building a ModelFrame to fit a model from data, this keyword will default to `has_intercept(T)` where `T` is your model type. To add the desired behaviour for your model (in my case CoxModel) you can simply overload it in a specific package. For example, in my case it would be:

```julia
StatsModels.has_intercept(::Type{CoxModel}) = false
```

I know there has been some discussion as to what is the default behaviour for intercept (add it by default or not, see #31 ), but here I'd actually prefer to sidestep that discussion and only add the possibility to exclude the intercept for some models.