### PR TITLE
de-unioninze model_response

### DIFF
--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -177,7 +177,7 @@ Extract the response column, if present.  `DataVector` or
 """
 function StatsBase.model_response(mf::ModelFrame)
     if mf.terms.response
-        convert(Array, mf.df[mf.terms.eterms[1]])
+        Missings.disallowmissing(convert(Array, mf.df[mf.terms.eterms[1]]))
     else
         error("Model formula one-sided")
     end

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -177,7 +177,8 @@ Extract the response column, if present.  `DataVector` or
 """
 function StatsBase.model_response(mf::ModelFrame)
     if mf.terms.response
-        Missings.disallowmissing(convert(Array, mf.df[mf.terms.eterms[1]]))
+        T = Missings.T(eltype(mf.terms.eterms[1]))
+        convert(Array{T}, mf.df[mf.terms.eterms[1]])
     else
         error("Model formula one-sided")
     end


### PR DESCRIPTION
Addresses #49 (and possibly JuliaStats/GLM.jl#210).

Before `Missings`, all that was needed to ensure the `model_response` was a standard vector was to convert it to an `Array` (from a `DataArray`).  Now, with missing values potentially represented in a `Array{Union{T,Missing}}`, it's also necessary to use something like `Missings.disallowmissing`.  This won't work with missings in Base (in 0.7), but seeing as we use other features like `Missings.T` elsewhere (like uniqueifying categorical vectors, https://github.com/JuliaStats/StatsModels.jl/blob/d7f285a9f6c8a98943391c9995bd1b3c3614e8a5/src/modelframe.jl#L105-L115) I think it's good enough for now.

The future-proof alternative would be to define those methods here since I don't think they're planned to be supported in Base, or wait until we have something like `typesubtract`.
