### PR TITLE
rip out formula parsing and replace it with something sane

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 DataFrames 0.11.5
 StatsBase 0.20.1
 Compat 0.63
+ArgCheck

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -3,7 +3,6 @@ __precompile__(true)
 module StatsModels
 
 using Compat
-using ArgCheck
 using DataFrames
 using StatsBase
 using Compat.SparseArrays

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -8,6 +8,7 @@ using DataFrames
 using StatsBase
 using Compat.SparseArrays
 using Compat.LinearAlgebra
+using Compat: @debug
 
 export @formula,
        Formula,

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -7,7 +7,7 @@ using DataFrames
 using StatsBase
 using Compat.SparseArrays
 using Compat.LinearAlgebra
-using Compat: @debug
+using Compat: @debug, @warn
 
 export @formula,
        Formula,

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -29,5 +29,6 @@ include("formula.jl")
 include("modelframe.jl")
 include("modelmatrix.jl")
 include("statsmodel.jl")
+include("deprecated.jl")
 
 end # module StatsModels

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -3,6 +3,7 @@ __precompile__(true)
 module StatsModels
 
 using Compat
+using ArgCheck
 using DataFrames
 using StatsBase
 using Compat.SparseArrays

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -24,14 +24,10 @@ export @formula,
        dropterm,
        setcontrasts!
 
-map(include,
-    [
-        "contrasts.jl",
-        "formula.jl",
-        "modelframe.jl",
-        "modelmatrix.jl",
-        "statsmodel.jl"
-    ])
-
+include("contrasts.jl")
+include("formula.jl")
+include("modelframe.jl")
+include("modelmatrix.jl")
+include("statsmodel.jl")
 
 end # module StatsModels

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,6 @@
+function Formula(lhs, rhs)
+    Base.depwarn("Formula(lhs, rhs) is deprecated. Use @eval(@formula($lhs ~ $rhs)) if " *
+                 "parsing is required, or Formula(ex_orig, ex, lhs, rhs) if not",
+                 :Formula)
+    Formula(:(), :($lhs ~ $rhs), lhs, rhs)
+end

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -165,7 +165,7 @@ function rewrite!(ex::Expr, child_idx::Int, ::Type{And1})
     @debug "    &1: $ex ->"
     ex.args[child_idx] == 1 ||
         @warn "Number $(ex.args[child_idx]) removed from interaction term $ex"
-    deleteat!(ex, child_idx)
+    deleteat!(ex.args, child_idx)
     @debug "        $ex"
     child_ex
 end
@@ -184,7 +184,7 @@ end
 parse!(x) = parse!(x, [And1, Subtraction, Star, AssociativeRule, Distributive])
 parse!(x, rewrites) = x
 function parse!(i::Integer, rewrites)
-    i ∈ [-1, 0, 1] throw(ArgumentError("invalid integer term $i (only -1, 0, and 1 allowed)"))
+    i ∈ [-1, 0, 1] || throw(ArgumentError("invalid integer term $i (only -1, 0, and 1 allowed)"))
     i
 end
 function parse!(ex::Expr, rewrites::Vector)

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -26,8 +26,8 @@ end
 
 macro formula(ex)
     try
-        @argcheck is_call(ex, :~) "expected formula separator ~, got $(ex.head)"
-        @argcheck length(ex.args) == 3 "malformed expression in formula $ex"
+        is_call(ex, :~) || throw(ArgumentError("expected formula separator ~, got $(ex.head)"))
+        length(ex.args) == 3 ||  throw(ArgumentError("malformed expression in formula $ex"))
         ex_orig = Meta.quot(copy(ex))
         sort_terms!(parse!(ex))
         lhs = Meta.quot(ex.args[2])
@@ -152,7 +152,7 @@ applies(ex::Expr, child_idx::Int, ::Type{Subtraction}) =
     is_call(ex.args[child_idx], :-)
 function rewrite!(ex::Expr, child_idx::Int, ::Type{Subtraction})
     child = ex.args[child_idx]
-    @argcheck child.args[3] == 1 "Can only subtract 1, got $child"
+    child.args[3] == 1 || throw(ArgumentError("Can only subtract 1, got $child"))
     child.args[1] = :+
     child.args[3] = -1
     child_idx
@@ -172,7 +172,7 @@ end
 parse!(x) = parse!(x, [Subtraction, Star, AssociativeRule, Distributive])
 parse!(x, rewrites) = x
 function parse!(i::Integer, rewrites)
-    @argcheck i ∈ [-1, 0, 1] "invalid integer term $i (only -1, 0, and 1 allowed)"
+    i ∈ [-1, 0, 1] throw(ArgumentError("invalid integer term $i (only -1, 0, and 1 allowed)"))
     i
 end
 function parse!(ex::Expr, rewrites::Vector)

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -28,17 +28,11 @@ macro formula(ex)
     try
         @argcheck is_call(ex, :~) "expected formula separator ~, got $(ex.head)"
         @argcheck length(ex.args) == 3 "malformed expression in formula $ex"
-        # if !is_call(ex, :~)
-        #     return :(throw(ArgumentError("expected formula separator ~, got $(ex.head)")))
-        # elseif length(ex.args) != 3
-        #     return :(throw(ArgumentError("malformed expression in formula $ex")))
-        # else
-            ex_orig = Meta.quot(copy(ex))
-            sort_terms!(parse!(ex))
-            lhs = Meta.quot(ex.args[2])
-            rhs = Meta.quot(ex.args[3])
-            return Expr(:call, :Formula, ex_orig, Meta.quot(ex), lhs, rhs)
-        # end
+        ex_orig = Meta.quot(copy(ex))
+        sort_terms!(parse!(ex))
+        lhs = Meta.quot(ex.args[2])
+        rhs = Meta.quot(ex.args[3])
+        return Expr(:call, :Formula, ex_orig, Meta.quot(ex), lhs, rhs)
     catch e
         return :(throw($e))
     end

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -164,7 +164,7 @@ rewrite!(ex::Expr, child_idx::Int, ::Nothing) = child_idx+1
 # like `findfirst` but returns the first element where predicate is true, or
 # nothing
 function filterfirst(f::Function, a::AbstractArray)
-    idx = findfirst(f, a)
+    idx = Compat.findfirst(f, a)
     idx === nothing ? nothing : a[idx]
 end
 

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -224,7 +224,7 @@ function degree(ex::Expr)
         length(ex.args) - 1
     elseif ex.args[1] == :|
         # put ranef terms at end
-        Inf
+        typemax(Int)
     else
         # arbitrary functions are treated as main effect terms
         1

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -231,8 +231,6 @@ function parse!(ex::Expr, rewrites::Vector)
     ex
 end
 
-# Base.copy(x::Nothing) = x
-# Base.copy(x::Symbol) = x
 
 function sort_terms!(ex::Expr)
     check_call(ex)
@@ -248,7 +246,6 @@ sort_terms!(x) = x
 
 degree(i::Integer) = 0
 degree(::Symbol) = 1
-# degree(s::Union{Symbol, ContinuousTerm, CategoricalTerm}) = 1
 function degree(ex::Expr)
     check_call(ex)
     if ex.args[1] == :&
@@ -270,9 +267,6 @@ end
 ## always return an ARRAY of terms
 getterms(ex::Expr) = is_call(ex, :+) ? ex.args[2:end] : Expr[ex]
 getterms(a::Any) = Any[a]
-
-# ord(ex::Expr) = (ex.head == :call && ex.args[1] == :&) ? length(ex.args)-1 : 1
-# ord(a::Any) = 1
 
 const nonevaluation = Set([:&,:|])        # operators constructed from other evaluations
 ## evaluation terms - the (filtered) arguments for :& and :|, otherwise the term itself

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -40,7 +40,6 @@ macro formula(ex)
             return Expr(:call, :Formula, ex_orig, Meta.quot(ex), lhs, rhs)
         # end
     catch e
-        @show dump(e)
         return :(throw($e))
     end
 end

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -167,7 +167,7 @@ function rewrite!(ex::Expr, child_idx::Int, ::Type{And1})
         @warn "Number $(ex.args[child_idx]) removed from interaction term $ex"
     deleteat!(ex.args, child_idx)
     @debug "        $ex"
-    child_ex
+    child_idx
 end
 
 # default re-write is a no-op (go to next child)

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -2,7 +2,7 @@
 
     d = DataFrame(x = CategoricalVector{Union{Missing, Symbol}}([:b, :a, :c, :a, :a, :b]))
 
-    mf = ModelFrame(Formula(nothing, :x), d)
+    mf = ModelFrame(@eval(@formula($(:($nothing~x)))), d)
 
     ## testing equality of ContrastsMatrix
     should_equal = [ContrastsMatrix(DummyCoding(), [:a, :b, :c]),
@@ -96,7 +96,8 @@
 
     # Missing data is handled gracefully, dropping columns when a level is lost
     d[3, :x] = missing
-    mf_missing = ModelFrame(Formula(nothing, :x), d, contrasts = Dict(:x => EffectsCoding()))
+    mf_missing = ModelFrame(@eval(@formula($(:($nothing ~ x)))), d,
+                            contrasts = Dict(:x => EffectsCoding()))
     @test ModelMatrix(mf_missing).m == [1  1
                                         1 -1
                                         1 -1

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,7 +1,7 @@
 @testset "Deprecations" begin
     f = @formula y ~ 1 + a*b
 
-    @static if VERSION > v"0.6.9999"
+    @static if VERSION > v"0.7.0-DEV.2988"
         f2 = @test_logs (:warn, r"Formula\(lhs, rhs\) is deprecated") Formula(f.lhs, f.rhs)
     else
         f2 = @test_warn "deprecated" Formula(f.lhs, f.rhs)

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,16 @@
+@testset "Deprecations" begin
+    f = @formula y ~ 1 + a*b
+
+    f2 = @test_warn "deprecated" Formula(f.lhs, f.rhs)
+    @test f2.lhs == f.lhs
+    @test f2.rhs == f.rhs
+    @test f2.ex == f.ex
+    @test f2.ex_orig == :()
+
+    f3 = @eval @formula $(f.lhs) ~ $(f.rhs)
+    @test f3.lhs == f.lhs
+    @test f3.rhs == f.rhs
+    @test f3.ex == f.ex
+    @test f3.ex_orig == f.ex
+    @test f3.ex_orig != f.ex_orig
+end

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,7 +1,12 @@
 @testset "Deprecations" begin
     f = @formula y ~ 1 + a*b
 
-    f2 = @test_warn "deprecated" Formula(f.lhs, f.rhs)
+    if VERSION > v"0.7.0-DEV"
+        testex = :(@test_logs (:warn, r"Formula\(lhs, rhs\) is deprecated") Formula($f.lhs, $f.rhs))
+    else
+        testex = :(@test_warn "deprecated" Formula($f.lhs, $f.rhs))
+    end
+    f2 = eval(testex)
     @test f2.lhs == f.lhs
     @test f2.rhs == f.rhs
     @test f2.ex == f.ex

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,12 +1,11 @@
 @testset "Deprecations" begin
     f = @formula y ~ 1 + a*b
 
-    if VERSION > v"0.7.0-DEV"
-        testex = :(@test_logs (:warn, r"Formula\(lhs, rhs\) is deprecated") Formula($f.lhs, $f.rhs))
+    @static if VERSION > v"0.6.9999"
+        f2 = @test_logs (:warn, r"Formula\(lhs, rhs\) is deprecated") Formula(f.lhs, f.rhs)
     else
-        testex = :(@test_warn "deprecated" Formula($f.lhs, $f.rhs))
+        f2 = @test_warn "deprecated" Formula(f.lhs, f.rhs)
     end
-    f2 = eval(testex)
     @test f2.lhs == f.lhs
     @test f2.rhs == f.rhs
     @test f2.ex == f.ex

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -96,12 +96,12 @@
                       :((&)(x1, x2, x3))]
     @test t.eterms == [:y, :x1, :x2, :x3]
 
-    ## Interactions with `1` reduce to main effect.  All fail at the moment.
+    ## Interactions with `1` reduce to main effect.
     t = Terms(@formula(y ~ 1 & x1))
-    @test_broken t.terms == [:x1]              # == [:(1 & x1)]
+    @test t.terms == [:x1]
 
     t = Terms(@formula(y ~ (1 + x1) & x2))
-    @test_broken t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
+    @test t.terms == [:x2, :(x1&x2)]
 
     ## PR #54 breaks formula-level equality because original (un-lowered)
     ## expression is kept on Formula struct.  but functional (RHS) equality

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -104,8 +104,8 @@
     ## @test t.terms == [:x2, :(x1&x2)]    # == [:(1 & x1)]
     ## @test t.eterms == [:y, :x1, :x2]
 
-    @test dropterm(@formula(foo ~ 1 + bar + baz), :bar) == @formula(foo ~ 1 + baz)
-    @test dropterm(@formula(foo ~ 1 + bar + baz), 1) == @formula(foo ~ 0 + bar + baz)
+    @test_broken dropterm(@formula(foo ~ 1 + bar + baz), :bar) == @formula(foo ~ 1 + baz)
+    @test_broken dropterm(@formula(foo ~ 1 + bar + baz), 1) == @formula(foo ~ 0 + bar + baz)
     @test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), 0)
     @test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), :boz)
     form = @formula(foo ~ 1 + bar + baz)

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -8,10 +8,10 @@
     # - support more transformations with I()?
 
     ## Formula parsing
-    import StatsModels: @formula, Formula, Terms
+    using StatsModels: @formula, Formula, Terms
 
     ## totally empty
-    t = Terms(Formula(nothing, 0))
+    t = Terms(@eval @formula $(:($nothing ~ 0)))
     @test t.response == false
     @test t.intercept == false
     @test t.terms == []
@@ -50,10 +50,13 @@
     @test t.intercept == false
     @test t.terms == [:x1, :x2]
 
-    @test t == Terms(@formula(y ~ -1 + x1 + x2)) == Terms(@formula(y ~ x1 - 1 + x2)) == Terms(@formula(y ~ x1 + x2 -1))
+    @test t ==
+        Terms(@formula(y ~ -1 + x1 + x2)) ==
+        Terms(@formula(y ~ x1 - 1 + x2)) ==
+        Terms(@formula(y ~ x1 + x2 -1))
 
     ## can't subtract terms other than 1
-    @test_throws ErrorException Terms(@formula(y ~ x1 - x2))
+    @test_throws ArgumentError Terms(@formula(y ~ x1 - x2))
 
     t = Terms(@formula(y ~ x1 & x2))
     @test t.terms == [:(x1 & x2)]
@@ -107,10 +110,10 @@
     @test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), :boz)
     form = @formula(foo ~ 1 + bar + baz)
     @test form == @formula(foo ~ 1 + bar + baz)
-    @test StatsModels.dropterm!(form, :bar) == @formula(foo ~ 1 + baz)
-    @test form == @formula(foo ~ 1 + baz)
+    @test_broken StatsModels.dropterm!(form, :bar) == @formula(foo ~ 1 + baz)
+    @test_broken form == @formula(foo ~ 1 + baz)
 
     # Incorrect formula separator
-    @test_throws ErrorException @formula(y => x + 1)
+    @test_throws ArgumentError @formula(y => x + 1)
 
 end

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -106,23 +106,20 @@
     ## PR #54 breaks formula-level equality because original (un-lowered)
     ## expression is kept on Formula struct.  but functional (RHS) equality
     ## should be maintained
-    @test_broken dropterm(@formula(foo ~ 1 + bar + baz), :bar) == @formula(foo ~ 1 + baz)
-    @test dropterm(@formula(foo ~ 1 + bar + baz), :bar).rhs == @formula(foo ~ 1 + baz).rhs
+    using StatsModels: dropterm!
 
-    @test_broken dropterm(@formula(foo ~ 1 + bar + baz), 1) == @formula(foo ~ 0 + bar + baz)
-    @test dropterm(@formula(foo ~ 1 + bar + baz), 1).rhs == @formula(foo ~ 0 + bar + baz).rhs
+    @test Terms(dropterm(@formula(foo ~ 1 + bar + baz), :bar)) ==
+        Terms(@formula(foo ~ 1 + baz))
+    @test Terms(dropterm(@formula(foo ~ 1 + bar + baz), 1)) ==
+        Terms(@formula(foo ~ 0 + bar + baz))
 
     @test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), 0)
     @test_throws ArgumentError dropterm(@formula(foo ~ 0 + bar + baz), :boz)
 
     form = @formula(foo ~ 1 + bar + baz)
     @test form == @formula(foo ~ 1 + bar + baz)
-
-    @test_broken StatsModels.dropterm!(form, :bar) == @formula(foo ~ 1 + baz)
-    @test StatsModels.dropterm!(form, :bar).rhs == @formula(foo ~ 1 + baz).rhs
-
-    @test_broken form == @formula(foo ~ 1 + baz)
-    @test form.rhs == @formula(foo ~ 1 + baz).rhs
+    @test Terms(dropterm!(form, :bar)) == Terms(@formula(foo ~ 1 + baz))
+    @test Terms(form) == Terms(@formula(foo ~ 1 + baz))
 
     # Incorrect formula separator
     @test_throws ArgumentError @formula(y => x + 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,8 @@ using StatsModels: ContrastsMatrix
 my_tests = ["formula.jl",
             "modelmatrix.jl",
             "statsmodel.jl",
-            "contrasts.jl"]
+            "contrasts.jl",
+            "deprecated.jl"]
 
 @testset "StatsModels" begin
     for tf in my_tests


### PR DESCRIPTION
This PR replaces the spaghetti code that handled the expression re-writes that transform formula surface syntax into a bunch main effects and interactions.  It works by specifying re-write rules (represented by subtypes of `FormulaRewrite`) for associative rule, distributive rule, "star expansion" (`a*b` to `a+b+a&b`), and subtraction (replacing `x-1` with `x + -1`).  These rules are implemented via methods on two functions: `applies(ex::Expr, child_idx::Int, ::Type{T<:FormulaRewrite})` and `rewrite!(ex::Expr, child_idx::Int, ::Type{T<:FormulaRewrite})`.  The first checks whether the child of `ex` at `child_idx` should be re-written under rule `T`, and the second modifies `ex` in place and returns the index of the next child to check.  For example, the associative rule checks whether `ex` and `ex.args[child_idx]` are both calls to the same associative operator, and splices the args of the child into `ex` in place of the child.

The goal here is to make the code easier to read, maintain, and extend.  Be expressing all the operations on the formula DSL in the same terms it'll be easier, I hope, to expand it or for package authors to implement custom extensions (although that may require using custom macros with the current implementation).  In the future I plan to change how the terms themselves are represented to make things even more composable and extensible, but I think the current PR should be considered regardless of that.

The only thing that's currently broken is the `drop_term!` tests: they're `Terms` are equivalent but the actual `Formulae` are not because I wasn't sure what the best way to modify the whole expression of the formula is (which I now store on the `Formula` struct, to hold onto both the _original_ (un-parsed) expression that's passed to the macro and the whole parsed expression).