### PR TITLE
unique from categoricalarrays 0.3.8

### DIFF
--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -102,9 +102,10 @@ end
 
 const DEFAULT_CONTRASTS = DummyCoding
 
-_unique(x::AbstractCategoricalArray) = sort!(unique(x))
+# get unique values, honoring levels order
+_unique(x::AbstractCategoricalArray) = intersect(levels(x), unique(x))
 _unique(x::AbstractCategoricalArray{T}) where {T>:Missing} =
-    convert(Array{Missings.T(T)}, filter!(!ismissing, sort!(unique(x))))
+    convert(Array{Missings.T(T)}, filter!(!ismissing, intersect(levels(x), unique(x))))
 
 function _unique(x::AbstractArray{T}) where T
     levs = T >: Missing ?

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -102,9 +102,9 @@ end
 
 const DEFAULT_CONTRASTS = DummyCoding
 
-_unique(x::AbstractCategoricalArray) = unique(x)
+_unique(x::AbstractCategoricalArray) = sort!(unique(x))
 _unique(x::AbstractCategoricalArray{T}) where {T>:Missing} =
-    convert(Array{Missings.T(T)}, filter!(!ismissing, unique(x)))
+    convert(Array{Missings.T(T)}, filter!(!ismissing, sort!(unique(x))))
 
 function _unique(x::AbstractArray{T}) where T
     levs = T >: Missing ?


### PR DESCRIPTION
CategoricalArrays 0.3.8 changes `unique` to return values in the order they are encountered, rather than the natural (sorted) order.  This uses `intersect(levels(x), unique(x))` to impose the order of levels on the values returned by `unique`.