### PR TITLE
WIP replace DataFrames with DataStreams Data.Table

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-DataFrames 0.11.5
+DataStreams
 StatsBase 0.20.1
 Compat 0.63

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-DataStreams
+DataStreams 0.3.0
 StatsBase 0.20.1
 Compat 0.63

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -3,7 +3,7 @@ __precompile__(true)
 module StatsModels
 
 using Compat
-using DataFrames
+using DataStreams
 using StatsBase
 using Compat.SparseArrays
 using Compat.LinearAlgebra

--- a/src/modelmatrix.jl
+++ b/src/modelmatrix.jl
@@ -26,12 +26,12 @@ Base.size(mm::ModelMatrix, dim...) = size(mm.m, dim...)
 ## construct model matrix columns from model frame + name (checks for contrasts)
 function modelmat_cols(::Type{T}, name::Symbol, mf::ModelFrame; non_redundant::Bool = false) where T<:AbstractFloatMatrix
     if haskey(mf.contrasts, name)
-        modelmat_cols(T, mf.df[name],
+        modelmat_cols(T, mf.dt[name],
                       non_redundant ?
                       convert(ContrastsMatrix{FullDummyCoding}, mf.contrasts[name]) :
                       mf.contrasts[name])
     else
-        modelmat_cols(T, mf.df[name])
+        modelmat_cols(T, mf.dt[name])
     end
 end
 
@@ -140,13 +140,13 @@ Mixed-effects models include "random-effects" terms which are ignored when
 creating the model matrix.
 """
 function ModelMatrix{T}(mf::ModelFrame) where T<:AbstractFloatMatrix
-    dfrm = mf.df
+    dfrm = mf.dt
     terms = droprandomeffects(dropresponse!(mf.terms))
 
     blocks = T[]
     assign = Int[]
     if terms.intercept
-        push!(blocks, ones(size(dfrm, 1), 1))  # columns of 1's is first block
+        push!(blocks, ones(_size(dfrm, 1), 1))  # columns of 1's is first block
         push!(assign, 0)                       # this block corresponds to term zero
     end
 
@@ -185,7 +185,7 @@ function ModelMatrix{T}(mf::ModelFrame) where T<:AbstractFloatMatrix
         error("Could not construct model matrix. Resulting matrix has 0 columns.")
     end
 
-    I = size(dfrm, 1)
+    I = _size(dfrm, 1)
     J = mapreduce(x -> size(x, 2), +, blocks)
     X = similar(blocks[1], I, J)
     i = 1

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,1 @@
-DataFrames 11.5
+DataFrames 0.11.5

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DataFrames 11.5

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -395,7 +395,7 @@
     mf = ModelFrame(@formula(y ~ 0 + x), df)
     X = ModelMatrix(mf).m
     X[1] = 0.0
-    @test mf.df[1, :x] === 1.0
+    @test mf.dt[1, :x] === 1.0
 
     # Ensure string columns are supported
     df1 = DataFrame(A = 1:4, B = categorical(["M", "F", "F", "M"]))


### PR DESCRIPTION
This introduces a marginally more backend-agnostic interface using DataStreams as a replacement for DataFrames: anything that can stream to a `Data.Table` (a named tuple of columns) can be used to make a ModelFrame.

Not all test pass yet (there's something funny with contrasts eltypes at least) but the basic functionality is there.

I copied some of the `completecases` code from DataFrames, but that's basically it. There's some ugliness because of how named tuples are constructed in 0.6 and 0.7, but it's pretty minimal.