### PR TITLE
Use stderror instead of stderr

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 DataFrames 0.11.5
-StatsBase 0.20.1
+StatsBase 0.22.0
 Compat 0.63

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -80,7 +80,7 @@ const DataFrameModels = Union{DataFrameStatisticalModel, DataFrameRegressionMode
                                  StatsBase.deviance, StatsBase.nulldeviance,
                                  StatsBase.loglikelihood, StatsBase.nullloglikelihood,
                                  StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
-                                 StatsBase.stderr, StatsBase.vcov]
+                                 StatsBase.stderror, StatsBase.vcov]
 @delegate DataFrameRegressionModel.model [StatsBase.residuals, StatsBase.model_response,
                                           StatsBase.predict, StatsBase.predict!]
 # Need to define these manually because of ambiguity using @delegate


### PR DESCRIPTION
The latter has been deprecated in StatsBase (https://github.com/JuliaStats/StatsBase.jl/pull/368).