### PR TITLE
delegate coefnames for wrapped models to model frame

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -103,7 +103,7 @@ function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; 
     return(out)
 end
 
-
+StatsBase.coefnames(model::DataFrameModels) = coefnames(model.mf)
 
 # coeftable implementation
 function StatsBase.coeftable(model::DataFrameModels)

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -62,6 +62,9 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
     m = fit(DummyMod, f, d)
     @test model_response(m) == Array(d[:y])
 
+    ## coefnames delegated to model frame by default
+    @test coefnames(m) == coefnames(ModelFrame(f, d)) == ["(Intercept)", "x1", "x2", "x1 & x2"]
+
     ## test prediction method
     ## vanilla
     @test predict(m) == [ ones(size(d,1)) Array(d[:x1]) Array(d[:x2]) Array(d[:x1]).*Array(d[:x2]) ] * collect(1:4)


### PR DESCRIPTION
This is a StatsBase API method that was missing.

fixes JuliaStats/GLM.jl#235