### PR TITLE
use something instead of coalesce in contrasts levels

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -137,7 +137,7 @@ function ContrastsMatrix(contrasts::AbstractContrasts, levels::AbstractVector)
     #    better to filter data frame first
     # 3. contrast levels missing from data: would have empty columns, generate a
     #    rank-deficient model matrix.
-    c_levels = coalesce(contrasts.levels, levels)
+    c_levels = something(contrasts.levels, levels)
     if eltype(c_levels) != eltype(levels)
         throw(ArgumentError("mismatching levels types: got $(eltype(levels)), expected " *
                             "$(eltype(c_levels)) based on contrasts levels."))

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -102,7 +102,7 @@ end
 Base.:(==)(t1::Terms, t2::Terms) = all(getfield(t1, f)==getfield(t2, f) for f in fieldnames(typeof(t1)))
 
 function Base.show(io::IO, f::Formula)
-    print(io, "Formula: ", coalesce(f.lhs, ""), " ~ ", f.rhs)
+    print(io, "Formula: ", something(f.lhs, ""), " ~ ", f.rhs)
 end
 
 


### PR DESCRIPTION
The levels of a contrasts struct are `nothing` by default, and are combined with the unique values using `coalesce`. `coalesce(nothing, 1)` on 0.6 returns `1`, but on 0.7 returns `nothing`.  The 0.7 solution is to use `something` instead.

also replace one other occurrence of `coalesce` (in printing LHS of one-sided formula).

fixes #65