### PR TITLE
fixes copy(::Formula) when rhs is a single Symbol

### DIFF
--- a/src/formula.jl
+++ b/src/formula.jl
@@ -206,7 +206,7 @@ end
 """
     And1 <: FormulaRewrite
 
-Remove numbers from interaction terms, so `1&x` becomes `&(x)` (which is later 
+Remove numbers from interaction terms, so `1&x` becomes `&(x)` (which is later
 cleaned up by `EmptyAnd`).
 """
 struct And1 <: FormulaRewrite end
@@ -362,7 +362,8 @@ end
 
 function Base.copy(f::Formula)
     lhs = isa(f.lhs, Symbol) ? f.lhs : copy(f.lhs)
-    return Formula(copy(f.ex_orig), copy(f.ex), lhs, copy(f.rhs))
+    rhs = isa(f.rhs, Symbol) ? f.rhs : copy(f.rhs)
+    return Formula(copy(f.ex_orig), copy(f.ex), lhs, rhs)
 end
 
 """

--- a/src/formula.jl
+++ b/src/formula.jl
@@ -360,10 +360,11 @@ function Formula(t::Terms)
     Formula(ex, ex, lhs,rhs)
 end
 
+copyside(s) = copy(s)
+copyside(s::Symbol) = s
+
 function Base.copy(f::Formula)
-    lhs = isa(f.lhs, Symbol) ? f.lhs : copy(f.lhs)
-    rhs = isa(f.rhs, Symbol) ? f.rhs : copy(f.rhs)
-    return Formula(copy(f.ex_orig), copy(f.ex), lhs, rhs)
+    return Formula(copy(f.ex_orig), copy(f.ex), copyside(f.lhs), copyside(f.rhs))
 end
 
 """

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -124,4 +124,11 @@
     # Incorrect formula separator
     @test_throws ArgumentError @formula(y => x + 1)
 
+    # copying formulas
+    f = @formula(foo ~ 1 + bar)
+    @test f == copy(f)
+
+    f = @formula(foo ~ bar)
+    @test f == copy(f)
+
 end


### PR DESCRIPTION
Added test on line 131 of test/formula.jl would fail, but now passes.