### PR TITLE
Fix predict for drop_intercept models

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -48,12 +48,12 @@ end
 """
     drop_intercept(::Type)
 
-Define whether a given model automatically drops the intercept. Return `false` by default. 
-To specify that a model type `T` drops the intercept, overload this function for the 
+Define whether a given model automatically drops the intercept. Return `false` by default.
+To specify that a model type `T` drops the intercept, overload this function for the
 corresponding type: `drop_intercept(::Type{T}) = true`
 
-Models that drop the intercept will be fitted without one: the intercept term will be 
-removed even if explicitly provided by the user. Categorical variables will be expanded 
+Models that drop the intercept will be fitted without one: the intercept term will be
+removed even if explicitly provided by the user. Categorical variables will be expanded
 in the rank-reduced form (contrasts for `n` levels will only produce `n-1` columns).
 """
 drop_intercept(::Type) = false
@@ -90,12 +90,14 @@ StatsBase.r2(mm::DataFrameRegressionModel, variant::Symbol) = r2(mm.model, varia
 StatsBase.adjr2(mm::DataFrameRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
 
 # Predict function that takes data frame as predictor instead of matrix
-function StatsBase.predict(mm::DataFrameRegressionModel, df::AbstractDataFrame; kwargs...)
+function StatsBase.predict(mm::DataFrameRegressionModel{T}, df::AbstractDataFrame; kwargs...) where T
     # copy terms, removing outcome if present (ModelFrame will complain if a
     # term is not found in the DataFrame and we don't want to remove elements with missing y)
     newTerms = dropresponse!(mm.mf.terms)
     # create new model frame/matrix
+    drop_intercept(T) && (newTerms.intercept = true)
     mf = ModelFrame(newTerms, df; contrasts = mm.mf.contrasts)
+    drop_intercept(T) && (mf.terms.intercept = false)
     newX = ModelMatrix(mf).m
     yp = predict(mm, newX; kwargs...)
     out = missings(eltype(yp), size(df, 1))

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -48,12 +48,12 @@ end
 """
     drop_intercept(::Type)
 
-Define whether a given model automatically drops the intercept. Return `false` by default.
-To specify that a model type `T` drops the intercept, overload this function for the
+Define whether a given model automatically drops the intercept. Return `false` by default. 
+To specify that a model type `T` drops the intercept, overload this function for the 
 corresponding type: `drop_intercept(::Type{T}) = true`
 
-Models that drop the intercept will be fitted without one: the intercept term will be
-removed even if explicitly provided by the user. Categorical variables will be expanded
+Models that drop the intercept will be fitted without one: the intercept term will be 
+removed even if explicitly provided by the user. Categorical variables will be expanded 
 in the rank-reduced form (contrasts for `n` levels will only produce `n-1` columns).
 """
 drop_intercept(::Type) = false

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -39,6 +39,8 @@ StatsBase.coeftable(mod::DummyModNoIntercept) =
               ["'beta' value"],
               ["" for n in 1:size(mod.x,2)],
               0)
+StatsBase.predict(mod::DummyModNoIntercept) = mod.x * mod.beta
+StatsBase.predict(mod::DummyModNoIntercept, newX::Matrix) = newX * mod.beta
 
 ## Another dummy model type to test fall-through show method
 struct DummyModTwo <: RegressionModel
@@ -122,14 +124,20 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
     ct1 = coeftable(m1)
     ct2 = coeftable(m2)
     @test ct1.rownms == ct2.rownms == ["x1", "x2", "x1 & x2"]
+    @test predict(m1, d[2:4, :]) == predict(m1)[2:4]
+    @test predict(m2, d[2:4, :]) == predict(m2)[2:4]
 
     f1 = @formula(y ~ 1 + x1p)
     f2 = @formula(y ~ 0 + x1p)
     m1 = fit(DummyModNoIntercept, f1, d)
     m2 = fit(DummyModNoIntercept, f2, d)
+    m3 = fit(DummyModNoIntercept, f3, d, contrasts = Dict(:x1p => EffectsCoding()))
     ct1 = coeftable(m1)
     ct2 = coeftable(m2)
     @test ct1.rownms == ct2.rownms == ["x1p: 6", "x1p: 7", "x1p: 8"]
+    @test predict(m1, d[2:4, :]) == predict(m1)[2:4]
+    @test predict(m2, d[2:4, :]) == predict(m2)[2:4]
+    @test predict(m3, d[2:4, :]) == predict(m3)[2:4]
 
     m2 = fit(DummyModTwo, f, d)
     show(io, m2)


### PR DESCRIPTION
For models M that specify drop_intercept(M) = true, the fit(M,Formula,df) function adds back and then drops the intercept just before creating the model frame. This same idiom also needs to be applied to predict() otherwise contrast variables are mishandled, resulting in a dimension mismatch error.
This PR:
- fixes predict with drop_intercept model and categorical variables bug
- add tests that used to fail but now pass