### PR TITLE
Explicitly ask for column names in evalcontrasts when calling eachcol.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.7-beta
-DataFrames 0.11.5
+DataFrames 0.15.0
 StatsBase 0.22.0
 Compat 0.63

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -121,7 +121,7 @@ end
 ## as the default)
 function evalcontrasts(df::AbstractDataFrame, contrasts::Dict = Dict())
     evaledContrasts = Dict()
-    for (term, col) in eachcol(df)
+    for (term, col) in eachcol(df, true)
         is_categorical(col) || continue
         evaledContrasts[term] = ContrastsMatrix(haskey(contrasts, term) ?
                                                 contrasts[term] :


### PR DESCRIPTION
The removes a warning which broke the GLM doctests. I plan to make a bugfix release once this is in.