### PR TITLE
Revert "Handle prediction that returns a confidence interval (#77)"

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -48,12 +48,12 @@ end
 """
     drop_intercept(::Type)
 
-Define whether a given model automatically drops the intercept. Return `false` by default.
-To specify that a model type `T` drops the intercept, overload this function for the
+Define whether a given model automatically drops the intercept. Return `false` by default. 
+To specify that a model type `T` drops the intercept, overload this function for the 
 corresponding type: `drop_intercept(::Type{T}) = true`
 
-Models that drop the intercept will be fitted without one: the intercept term will be
-removed even if explicitly provided by the user. Categorical variables will be expanded
+Models that drop the intercept will be fitted without one: the intercept term will be 
+removed even if explicitly provided by the user. Categorical variables will be expanded 
 in the rank-reduced form (contrasts for `n` levels will only produce `n-1` columns).
 """
 drop_intercept(::Type) = false
@@ -100,10 +100,8 @@ function StatsBase.predict(mm::DataFrameRegressionModel{T}, df::AbstractDataFram
     drop_intercept(T) && (mf.terms.intercept = false)
     newX = ModelMatrix(mf).m
     yp = predict(mm, newX; kwargs...)
-    # if `interval = :confidence` in the kwargs, `yp` will be a 3-column matrix
-    outsize = yp isa Matrix ? (size(df, 1), 3) : size(df,1)
-    out = missings(eltype(yp), outsize)
-    out[mf.nonmissing, :] = yp
+    out = missings(eltype(yp), size(df, 1))
+    out[mf.nonmissing] = yp
     return(out)
 end
 


### PR DESCRIPTION
This reverts commit a64cb50f2e8cfc0e8718fd7651458cd15373d934.

As discussed in #77. Once this has been merged, I'll make a new release and should be able to finish the `predict` behavior without any rush. (@nalimilan we already require DataFrames 0.15 which includes the two argument `eachcol` methods, see https://github.com/JuliaData/DataFrames.jl/commit/dcac4bc383231388629f25877e7b1304cffe0632.)