### PR TITLE
accept namedtuples and return a DataFrame

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -48,12 +48,12 @@ end
 """
     drop_intercept(::Type)
 
-Define whether a given model automatically drops the intercept. Return `false` by default. 
-To specify that a model type `T` drops the intercept, overload this function for the 
+Define whether a given model automatically drops the intercept. Return `false` by default.
+To specify that a model type `T` drops the intercept, overload this function for the
 corresponding type: `drop_intercept(::Type{T}) = true`
 
-Models that drop the intercept will be fitted without one: the intercept term will be 
-removed even if explicitly provided by the user. Categorical variables will be expanded 
+Models that drop the intercept will be fitted without one: the intercept term will be
+removed even if explicitly provided by the user. Categorical variables will be expanded
 in the rank-reduced form (contrasts for `n` levels will only produce `n-1` columns).
 """
 drop_intercept(::Type) = false
@@ -100,8 +100,10 @@ function StatsBase.predict(mm::DataFrameRegressionModel{T}, df::AbstractDataFram
     drop_intercept(T) && (mf.terms.intercept = false)
     newX = ModelMatrix(mf).m
     yp = predict(mm, newX; kwargs...)
-    out = missings(eltype(yp), size(df, 1))
-    out[mf.nonmissing] = yp
+    # if `interval = :confidence` in the kwargs, `yp` will be a 3-column matrix
+    outsize = yp isa Matrix ? (size(df, 1), 3) : size(df,1)
+    out = missings(eltype(yp), outsize)
+    out[mf.nonmissing, :] = yp
     return(out)
 end
 

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -98,14 +98,14 @@ end
 function _return_predictions(yp::AbstractMatrix, nonmissings, len)
     out = missings(eltype(yp), (len, 3))
     out[nonmissings, :] = yp
-    DataFrame(y = out[:,1], lower = out[:,2], upper = out[:,3])
+    DataFrame(prediction = out[:,1], lower = out[:,2], upper = out[:,3])
 end
 
 function _return_predictions(yp::NamedTuple, nonmissings, len)
-    y = missings(eltype(yp[:y]), len)
+    y = missings(eltype(yp[:prediction]), len)
     l, h = similar(y), similar(y)
-    out = (y = y, lower = l, upper = h)
-    for key in (:y, :lower, :upper)
+    out = (prediction = y, lower = l, upper = h)
+    for key in (:prediction, :lower, :upper)
         out[key][nonmissings] = yp[key]
     end
     DataFrame(out)

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -98,14 +98,14 @@ end
 function _return_predictions(yp::AbstractMatrix, nonmissings, len)
     out = missings(eltype(yp), (len, 3))
     out[nonmissings, :] = yp
-    DataFrame(newy = out[:,1], lower = out[:,2], upper = out[:,3])
+    DataFrame(y = out[:,1], lower = out[:,2], upper = out[:,3])
 end
 
 function _return_predictions(yp::NamedTuple, nonmissings, len)
-    y = missings(eltype(yp[:newy]), len)
+    y = missings(eltype(yp[:y]), len)
     l, h = similar(y), similar(y)
-    out = (newy = y, lower = l, upper = h)
-    for key in (:newy, :lower, :upper)
+    out = (y = y, lower = l, upper = h)
+    for key in (:y, :lower, :upper)
         out[key][nonmissings] = yp[key]
     end
     DataFrame(out)


### PR DESCRIPTION
As discussed on Slack. Some considerations:

1. I have made it accept both a Matrix or a NamedTuple. That makes it independent of the GLM version. I don't know if that's desirable but it was suggested on the slack.
2. I have made it return a DataFrame for now as that is what it accepts. We can edit for Tables when Terms 2.0 is merged I guess?
3. I have used dispatch on a nonexported helper function rather than testing the types with if statements. Not sure what the style is here.
4. There is no single-argument `predict(mymodel, interval = :confidence)` method. Where should that be added, here or in GLM?
