### PR TITLE
Support keyword arguments in coeftable(::TableModels)

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -169,8 +169,8 @@ end
 StatsBase.coefnames(model::TableModels) = coefnames(model.mf)
 
 # coeftable implementation
-function StatsBase.coeftable(model::TableModels)
-    ct = coeftable(model.model)
+function StatsBase.coeftable(model::TableModels; kwargs...)
+    ct = coeftable(model.model, kwargs...)
     cfnames = coefnames(model.mf)
     if length(ct.rownms) == length(cfnames)
         ct.rownms = cfnames


### PR DESCRIPTION
Needed in particular for the new `level` keyword argument documented in the StatsBase API (https://github.com/JuliaStats/StatsBase.jl/pull/406).