### PR TITLE
just copy continuous terms in modelcols, don't convert to float64

### DIFF
--- a/src/terms.jl
+++ b/src/terms.jl
@@ -472,7 +472,7 @@ modelcols(ts::TupleTerm, d::NamedTuple) = modelcols.(ts, Ref(d))
 modelcols(ft::FunctionTerm{Fo,Fa,Names}, d::NamedTuple) where {Fo,Fa,Names} =
     ft.fanon.(getfield.(Ref(d), Names)...)
 
-modelcols(t::ContinuousTerm, d::NamedTuple) = Float64.(d[t.sym])
+modelcols(t::ContinuousTerm, d::NamedTuple) = copy.(d[t.sym])
 
 modelcols(t::CategoricalTerm, d::NamedTuple) = t.contrasts[d[t.sym], :]
 


### PR DESCRIPTION
Miraculously, tests pass with just this change.  The reason is that the underlying columns are all `hcat`ed together at the last stage, and for most of the normal cases there's an intercept term (or a non-intercept term), both of which are arrays with eltype Float64.

It might be possible to get away without even copying, just passing the underlying column straight through, as long as we do defensive copy at the very last stage (matrix term seems like a reasonable place to do this).  But that might be overkill.

This doesn't address the possibility that someone might want a model matrix that's not just Float64s.

As a note to self, I think the long-term solution is to create the model matrix in-place, which would require adding `modelcols!` or some such.  That would reduce copies to a minimum but be a bit more complex (the "setup" stage where you create the empty array of the desired type needs to be handled).

(partially) fixes JuliaStats/Survival.jl#10