### PR TITLE
Clean up tuples with sum after apply_schema

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -207,8 +207,7 @@ in _most_ cases, but cause method ambiguity in some.
 """
 apply_schema(t, schema) = apply_schema(t, schema, Nothing)
 apply_schema(t, schema, Mod::Type) = t
-apply_schema(terms::TupleTerm, schema, Mod::Type) =
-    apply_schema.(terms, Ref(schema), Mod)
+apply_schema(terms::TupleTerm, schema, Mod::Type) = sum(apply_schema.(terms, Ref(schema), Mod))
 
 apply_schema(t::Term, schema::Schema, Mod::Type) = schema[t]
 apply_schema(ft::FormulaTerm, schema::Schema, Mod::Type) =

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -1,6 +1,6 @@
 abstract type AbstractTerm end
-const TupleTerm = NTuple{N, AbstractTerm} where N
 const TermOrTerms = Union{AbstractTerm, NTuple{N, AbstractTerm} where N}
+const TupleTerm = NTuple{N, TermOrTerms} where N
 
 width(::T) where {T<:AbstractTerm} =
     throw(ArgumentError("terms of type $T have undefined width"))


### PR DESCRIPTION
This is necessary to support special terms that return a tuple of other terms.
This would also allow supporting `*` or even R's `^` via normal "special term"
mechanisms.