### PR TITLE
Handle MatrixTerm when calculating column-to-term indexes in ModelMatrix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/modelframe.jl
+++ b/src/modelframe.jl
@@ -172,11 +172,16 @@ end
 
 Base.size(mm::ModelMatrix, dim...) = size(mm.m, dim...)
 
+asgn(f::FormulaTerm) = asgn(f.rhs)
+asgn(mt::MatrixTerm) = asgn(mt.terms)
+asgn(t) = mapreduce(((i,t), ) -> i*ones(width(t)),
+                    append!,
+                    enumerate(vectorize(t)),
+                    init=Int[])
+
 function ModelMatrix{T}(mf::ModelFrame) where T<:AbstractMatrix{<:AbstractFloat}
     mat = modelmatrix(mf)
-    asgn = mapreduce((it)->first(it)*ones(width(last(it))), append!,
-                     enumerate(vectorize(mf.f.rhs)), init=Int[])
-    ModelMatrix(convert(T, mat), asgn)
+    ModelMatrix(convert(T, mat), asgn(mf.f))
 end
 
 ModelMatrix(mf::ModelFrame) = ModelMatrix{Matrix{Float64}}(mf)

--- a/test/modelframe.jl
+++ b/test/modelframe.jl
@@ -1,0 +1,13 @@
+@testset "ModelFrame (legacy API)" begin
+
+    @testset "#133" begin
+        df = (x = rand(12),
+              y = categorical(repeat(1:3, inner=4)),
+              z = categorical(repeat(1:2, outer=6)));
+        f = @formula(x ~ y * z);
+        mf = ModelFrame(f, df)
+        mm = ModelMatrix(mf)
+        @test mm.assign == [1, 2, 2, 3, 4, 4]
+    end
+    
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ my_tests = ["formula.jl",
             "temporal_terms.jl",
             "schema.jl",
             "modelmatrix.jl",
+            "modelframe.jl",
             "statsmodel.jl",
             "contrasts.jl",
             "extension.jl"]


### PR DESCRIPTION
There was a bug (#133) in how terms are enumerated for the purposes of finding
the term index corresponding to each column of the `ModelMatrix`.  This makes
the handling of that more robust by adding an internal `asgn` function.

Note that the returned indexes are different in 0.6+ since the intercept is
included as a term, instead of being given index 0.

Fixes #133