### PR TITLE
Make modelcols(::Term, d) an error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.2"
+version = "0.6.3"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -468,6 +468,10 @@ julia> modelcols(MatrixTerm(ts), d)
 """
 modelcols(ts::TupleTerm, d::NamedTuple) = modelcols.(ts, Ref(d))
 
+modelcols(t::Term, d::NamedTuple) =
+    throw(ArgumentError("can't generate modelcols for un-typed term $t. " *
+                        "Use apply_schema to create concrete terms first"))
+
 # TODO: @generated to unroll the getfield stuff
 modelcols(ft::FunctionTerm{Fo,Fa,Names}, d::NamedTuple) where {Fo,Fa,Names} =
     ft.fanon.(getfield.(Ref(d), Names)...)

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -419,6 +419,11 @@ converted to a `NamedTuple` of `Vectors` (e.g., a `Tables.ColumnTable`).
 """
 function modelcols(t, d::D) where D
     Tables.istable(d) || throw(ArgumentError("Data of type $D is not a table!"))
+    ## throw an error for t which don't have a more specific modelcols method defined
+    ## TODO: this seems like it ought to be handled by dispatching on something
+    ## like modelcols(::Any, ::NamedTuple) or modelcols(::AbstractTerm, ::NamedTuple)
+    ## but that causes ambiguity errors or under-constrained modelcols methods for
+    ## custom term types...
     d isa NamedTuple && throw(ArgumentError("don't know how to generate modelcols for " *
                                             "term $t. Did you forget to call apply_schema?"))
     modelcols(t, columntable(d))

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -419,6 +419,8 @@ converted to a `NamedTuple` of `Vectors` (e.g., a `Tables.ColumnTable`).
 """
 function modelcols(t, d::D) where D
     Tables.istable(d) || throw(ArgumentError("Data of type $D is not a table!"))
+    d isa NamedTuple && throw(ArgumentError("don't know how to generate modelcols for " *
+                                            "term $t. Did you forget to call apply_schema?"))
     modelcols(t, columntable(d))
 end
 

--- a/test/extension.jl
+++ b/test/extension.jl
@@ -24,6 +24,9 @@ StatsModels.apply_schema(t::NonMatrixTerm, sch, Mod::Type) =
     NonMatrixTerm(apply_schema(t.term, sch, Mod))
 StatsModels.modelcols(t::NonMatrixTerm, d) = modelcols(t.term, d)
 
+struct DummyTerm <: AbstractTerm
+end
+
 @testset "Extended formula/models" begin
     d = (z = rand(10), y = rand(10), x = collect(1:10))
     sch = schema(d)
@@ -87,5 +90,7 @@ StatsModels.modelcols(t::NonMatrixTerm, d) = modelcols(t.term, d)
         
     end
 
+    @testset "Fallback" begin
+        @test_throws ArgumentError modelcols(DummyTerm(), (a=[1], ))
+    end
 end
-

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -374,4 +374,10 @@
         end
     end
 
+    @testset "#136" begin
+        t = (x = rand(100), y = randn(100));
+        f = @formula(y ~ x)
+        @test_throws ArgumentError modelcols(f, t)
+    end
+
 end


### PR DESCRIPTION
This fixes #136 (stackoverflow when there's no more specific method than
`modelcols(::Any, ::Any)`).  An alternative would be to just return the
underlying column (which is probably what we'd want if we do something like
#117).  Making it an explicit error for now means that people can't rely on that
behavior until we've made a decision about what we want long-term.

One larger issue that I'm not sure how to address is that there's currently no
sensible fallback for `::AbstractTerm`s that don't have modelcols methods.
There shouldn't be any of those at this point but if there _are_ then they will
produce the same stack overflow as #136.  The problem is that when you add
methods like `modelcols(::AbstractTerm, ::Any)` or `modelcols(::AbstractTerm,
::NamedTuple)` you get ambiguity errors or problems when custom terms don't
specialize their `modelcols` methods on the data type.  A potential workaround
would be to put a check in the `modelcols(::Any, ::Any)` that checks if the
second argument is already a named tuple and throws an error if it is, but that
feels like kind of a hack.