### PR TITLE
One-sided formula, 2.0

### DIFF
--- a/src/formula.jl
+++ b/src/formula.jl
@@ -59,7 +59,7 @@ The rules that are applied are
 """
 macro formula(ex)
     is_call(ex, :~) || throw(ArgumentError("expected formula separator ~, got $(ex.head)"))
-    length(ex.args) == 3 ||  throw(ArgumentError("malformed expression in formula $ex"))
+    length(ex.args) in (2,3) ||  throw(ArgumentError("malformed expression in formula $ex"))
     terms!(sort_terms!(parse!(ex)))
 end
 

--- a/src/schema.jl
+++ b/src/schema.jl
@@ -8,6 +8,7 @@
 # TODO: handle streaming (Data.RowTable) by iterating over rows and updating
 # schemas in place
 
+terms(t) = AbstractTerm[]
 terms(t::FormulaTerm) = union(terms(t.lhs), terms(t.rhs))
 terms(t::InteractionTerm) = terms(t.terms)
 terms(t::FunctionTerm{Fo,Fa,names}) where {Fo,Fa,names} = Term.(names)
@@ -243,6 +244,8 @@ has_schema(t::Union{ContinuousTerm,CategoricalTerm}) = true
 has_schema(t::InteractionTerm) = all(has_schema(tt) for tt in t.terms)
 has_schema(t::TupleTerm) = all(has_schema(tt) for tt in t)
 has_schema(t::FormulaTerm) = has_schema(t.lhs) && has_schema(t.rhs)
+# because apply_schema(x::Any, ...) = x
+has_schema(t) = true
 
 struct FullRank
     schema::Schema

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -352,9 +352,11 @@ Base.show(io::IO, t::ConstantTerm) = print(io, t.n)
 Base.show(io::IO, t::FormulaTerm) = print(io, "$(t.lhs) ~ $(t.rhs)")
 function Base.show(io::IO, mime::MIME"text/plain", t::FormulaTerm; prefix="")
     println(io, "FormulaTerm")
-    print(io, "Response:")
-    show(io, mime, t.lhs, prefix="\n  ")
-    println(io)
+    if t.lhs !== nothing
+        print(io, "Response:")
+        show(io, mime, t.lhs, prefix="\n  ")
+        println(io)
+    end
     print(io, "Predictors:")
     show(io, mime, t.rhs, prefix="\n  ")
 end
@@ -395,6 +397,7 @@ Base.show(io::IO, mime::MIME"text/plain", t::MatrixTerm; prefix="") =
 
 
 Base.:~(lhs::TermOrTerms, rhs::TermOrTerms) = FormulaTerm(lhs, rhs)
+Base.:~(rhs::TermOrTerms) = FormulaTerm(nothing, rhs)
 
 Base.:&(terms::AbstractTerm...) = InteractionTerm(terms)
 Base.:&(term::AbstractTerm) = term
@@ -428,6 +431,8 @@ function modelcols(t, d::D) where D
                                             "term $t. Did you forget to call apply_schema?"))
     modelcols(t, columntable(d))
 end
+
+modelcols(::Nothing, ::NamedTuple) = nothing
 
 """
     modelcols(ts::NTuple{N, AbstractTerm}, data) where N
@@ -566,7 +571,7 @@ omitsintercept(t::AbstractTerm) =
     ConstantTerm(-1) ∈ terms(t)
 
 hasresponse(t) = false
-hasresponse(t::FormulaTerm{LHS}) where {LHS} = LHS !== nothing
+hasresponse(t::FormulaTerm{LHS}) where {LHS} = LHS !== Nothing
 
 # convenience converters
 """

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -5,11 +5,12 @@
     y, x1, x2, x3, a, b, c, onet = term.((:y, :x1, :x2, :x3, :a, :b, :c, 1))
 
     ## totally empty
-    @test_broken t = @eval @formula $(:($nothing ~ 0))
-    @test_broken hasresponse(t) == false
-    @test_broken hasintercept(t) == false
-    @test_broken t.rhs == ConstantTerm(0)
-    @test_broken issetequal(terms(t), [ConstantTerm(0)])
+    t = @formula(~0)
+    @test !hasresponse(t)
+    @test !hasintercept(t)
+    @test omitsintercept(t)
+    @test t.rhs == ConstantTerm(0)
+    @test issetequal(terms(t), [ConstantTerm(0)])
 
     ## empty RHS
     t = @formula(y ~ 0)


### PR DESCRIPTION
This supersedes #20 and provides support for one-sided formulae.  The required
changes were surprisingly minimal and non-disruptive (and eliminate nearly half
of the "broken" tests!).  The strategy is to put `nothing` on the LHS, which is
handled by a one-arg method.

``` julia
~(t::TermOrTerms) = ~(nothing, t)
```

And return `nothing` for `modelcols(::Nothing, d)`.  The only wart is you have
to do `@formula(~(1 + x + y))` to make sure that `~` parses correctly (the
precedence is different for prefix vs. infix).  The macro tweak from #20 could
fix that but I'm not sure it's worth it.