### PR TITLE
Fix intercept detector traits and hasresponse

### DIFF
--- a/src/terms.jl
+++ b/src/terms.jl
@@ -559,14 +559,19 @@ StatsBase.coefnames(t::InteractionTerm) =
 ################################################################################
 # old Terms features:
 
+hasintercept(f::FormulaTerm) = hasintercept(f.rhs)
 hasintercept(t::AbstractTerm) = InterceptTerm{true}() ∈ terms(t) || ConstantTerm(1) ∈ terms(t)
+omitsintercept(f::FormulaTerm) = omitsintercept(f.rhs)
 omitsintercept(t::AbstractTerm) =
     InterceptTerm{false}() ∈ terms(t) ||
     ConstantTerm(0) ∈ terms(t) ||
     ConstantTerm(-1) ∈ terms(t)
 
 hasresponse(t) = false
-hasresponse(t::FormulaTerm{LHS}) where {LHS} = LHS !== nothing
+hasresponse(t::FormulaTerm) =
+    t.lhs !== nothing && 
+    t.lhs != ConstantTerm(0) &&
+    t.lhs != InterceptTerm{false}
 
 # convenience converters
 """

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -572,8 +572,8 @@ omitsintercept(t::TermOrTerms) =
 hasresponse(t) = false
 hasresponse(t::FormulaTerm) =
     t.lhs !== nothing && 
-    t.lhs != ConstantTerm(0) &&
-    t.lhs != InterceptTerm{false}()
+    t.lhs !== ConstantTerm(0) &&
+    t.lhs !== InterceptTerm{false}()
 
 # convenience converters
 """

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -560,9 +560,11 @@ StatsBase.coefnames(t::InteractionTerm) =
 # old Terms features:
 
 hasintercept(f::FormulaTerm) = hasintercept(f.rhs)
-hasintercept(t::AbstractTerm) = InterceptTerm{true}() ∈ terms(t) || ConstantTerm(1) ∈ terms(t)
+hasintercept(t::TermOrTerms) =
+    InterceptTerm{true}() ∈ terms(t) ||
+    ConstantTerm(1) ∈ terms(t)
 omitsintercept(f::FormulaTerm) = omitsintercept(f.rhs)
-omitsintercept(t::AbstractTerm) =
+omitsintercept(t::TermOrTerms) =
     InterceptTerm{false}() ∈ terms(t) ||
     ConstantTerm(0) ∈ terms(t) ||
     ConstantTerm(-1) ∈ terms(t)
@@ -571,7 +573,7 @@ hasresponse(t) = false
 hasresponse(t::FormulaTerm) =
     t.lhs !== nothing && 
     t.lhs != ConstantTerm(0) &&
-    t.lhs != InterceptTerm{false}
+    t.lhs != InterceptTerm{false}()
 
 # convenience converters
 """

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -22,6 +22,7 @@
     t = @formula(y ~ 0)
     @test hasintercept(t) == false
     @test omitsintercept(t) == true
+    @test hasresponse(t)
     @test t.rhs == ConstantTerm(0)
     @test issetequal(terms(t), term.((:y, 0)))
 

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -5,11 +5,18 @@
     y, x1, x2, x3, a, b, c, onet = term.((:y, :x1, :x2, :x3, :a, :b, :c, 1))
 
     ## totally empty
-    @test_broken t = @eval @formula $(:($nothing ~ 0))
-    @test_broken hasresponse(t) == false
-    @test_broken hasintercept(t) == false
-    @test_broken t.rhs == ConstantTerm(0)
-    @test_broken issetequal(terms(t), [ConstantTerm(0)])
+    t = @formula(0 ~ 0)
+    @test !hasresponse(t)
+    @test !hasintercept(t)
+    @test omitsintercept(t)
+    @test t.rhs == ConstantTerm(0)
+    @test issetequal(terms(t), [ConstantTerm(0)])
+
+    ## empty lhs, intercept on rhs
+    t = @formula(0 ~ 1)
+    @test !hasresponse(t)
+    @test hasintercept(t)
+    @test !omitsintercept(t)
 
     ## empty RHS
     t = @formula(y ~ 0)

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -92,4 +92,61 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
 
         @test terms2 == terms3
     end
+
+    @testset "Intercept and response traits" begin
+
+        has_responses = [term(:y), term(1), InterceptTerm{true}(), term(:y)+term(:z),
+                        term(:y) + term(0), term(:y) + InterceptTerm{false}()]
+        no_responses = [term(0), InterceptTerm{false}()]
+
+        has_intercepts = [term(1), InterceptTerm{true}()]
+        omits_intercepts = [term(0), term(-1), InterceptTerm{false}()]
+
+        using StatsModels: hasresponse, hasintercept, omitsintercept
+
+        a = term(:a)
+
+        for lhs in has_responses, rhs in has_intercepts
+            @test hasresponse(lhs ~ rhs)
+            @test hasintercept(lhs ~ rhs)
+            @test !omitsintercept(lhs ~ rhs)
+
+            @test hasresponse(lhs ~ rhs + a)
+            @test hasintercept(lhs ~ rhs + a)
+            @test !omitsintercept(lhs ~ rhs + a)
+
+        end
+
+        for lhs in no_responses, rhs in has_intercepts
+            @test !hasresponse(lhs ~ rhs)
+            @test hasintercept(lhs ~ rhs)
+            @test !omitsintercept(lhs ~ rhs)
+
+            @test !hasresponse(lhs ~ rhs + a)
+            @test hasintercept(lhs ~ rhs + a)
+            @test !omitsintercept(lhs ~ rhs + a)
+        end
+
+        for lhs in has_responses, rhs in omits_intercepts
+            @test hasresponse(lhs ~ rhs)
+            @test !hasintercept(lhs ~ rhs)
+            @test omitsintercept(lhs ~ rhs)
+
+            @test hasresponse(lhs ~ rhs + a)
+            @test !hasintercept(lhs ~ rhs + a)
+            @test omitsintercept(lhs ~ rhs + a)
+        end
+
+        for lhs in no_responses, rhs in omits_intercepts
+            @test !hasresponse(lhs ~ rhs)
+            @test !hasintercept(lhs ~ rhs)
+            @test omitsintercept(lhs ~ rhs)
+
+            @test !hasresponse(lhs ~ rhs + a)
+            @test !hasintercept(lhs ~ rhs + a)
+            @test omitsintercept(lhs ~ rhs + a)
+        end
+
+    end
+    
 end


### PR DESCRIPTION
This improves support for using `0` on the LHS for a one-sided formula by making
sure that the `hasintercept` and `omitsintercept` traits are detected correctly
when `0` is present on the LHS.  Currently `0` on the LHS triggers the "omits
intercept" trait which blocks the default inclusion of the intercept for
`StatisticalModel` contexts.

This also updates the `hasresponse` detector to treat LHS `0` as no response.