### PR TITLE
Implement HypothesisCoding and ~un-export~ deprecate ContrastsCoding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.7"
+version = "0.6.8"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/docs/src/contrasts.md
+++ b/docs/src/contrasts.md
@@ -1,5 +1,9 @@
 ```@meta
 CurrentModule = StatsModels
+DocTestSetup = quote
+    using StatsModels
+    using LinearAlgebra
+end
 ```
 
 # Modeling categorical data
@@ -14,7 +18,7 @@ The following contrast coding systems are implemented:
 * [`DummyCoding`](@ref)
 * [`EffectsCoding`](@ref)
 * [`HelmertCoding`](@ref)
-* [`ContrastsCoding`](@ref)
+* [`HypothesisCoding`](@ref)
 
 ## How to specify contrast coding
 
@@ -44,13 +48,14 @@ ContrastsMatrix
 DummyCoding
 EffectsCoding
 HelmertCoding
-ContrastsCoding
+HypothesisCoding
 ```
 
 ### Special internal contrasts
 
 ```@docs
 FullDummyCoding
+ContrastsCoding
 ```
 
 ## Further details

--- a/docs/src/contrasts.md
+++ b/docs/src/contrasts.md
@@ -19,6 +19,7 @@ The following contrast coding systems are implemented:
 * [`EffectsCoding`](@ref)
 * [`HelmertCoding`](@ref)
 * [`HypothesisCoding`](@ref)
+* [`SeqDiffCoding`](@ref)
 
 ## How to specify contrast coding
 
@@ -48,6 +49,7 @@ ContrastsMatrix
 DummyCoding
 EffectsCoding
 HelmertCoding
+SeqDiffCoding
 HypothesisCoding
 ```
 

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -24,8 +24,8 @@ export
     EffectsCoding,
     DummyCoding,
     HelmertCoding,
-    ContrastsCoding,
-
+    HypothesisCoding,
+    
     coefnames,
     dropterm,
     setcontrasts!,

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -24,6 +24,7 @@ export
     EffectsCoding,
     DummyCoding,
     HelmertCoding,
+    SeqDiffCoding,
     HypothesisCoding,
     
     coefnames,

--- a/src/StatsModels.jl
+++ b/src/StatsModels.jl
@@ -26,6 +26,7 @@ export
     HelmertCoding,
     SeqDiffCoding,
     HypothesisCoding,
+    ContrastsCoding,
     
     coefnames,
     dropterm,

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -418,9 +418,11 @@ end
 
 Specify how to code a categorical variable in terms of a *hypothesis matrix*.
 For a variable with ``k`` levels, this should be a ``k-1 \times k`` matrix.
-Each row of the matrix corresponds to the hypothesis tested by the
-corresponding predictor, given as the weights given to the "cell mean" of each
-of the ``k`` values of the predictor.
+Each row of the matrix corresponds corresponds to a hypothesis about the mean
+outcomes under each of the ``k`` levels of the predictor.  The entries in the
+row give the weights assigned to each of these ``k`` means, and the
+corresponding predictor in a regression model estimates the weighted sum of
+these cell means.
 
 For instance, if we have a variable which has four levels A, B, C, and D, and we
 want to test the hypothesis that the difference between the average outcomes for
@@ -459,6 +461,10 @@ julia> StatsModels.ContrastsMatrix(HypothesisCoding(sdiff_hypothesis), ["a", "b"
   0.25   0.5   0.75
 ```
 
+The interpretation of the such "sequential difference" contrasts are clear when
+expressed as a hypothesis matrix, but it is not obvious just from looking at the
+contrasts matrix.  For this reason `HypothesisCoding` is preferred for
+specifying custom contrast coding schemes over `ContrastsCoding`.
 
 """
 mutable struct HypothesisCoding <: AbstractContrasts
@@ -498,6 +504,9 @@ mutable struct ContrastsCoding <: AbstractContrasts
     levels::Union{Vector,Nothing}
 
     function ContrastsCoding(mat, base, levels)
+        Base.depwarn("`ContrastsCoding(contrasts)` is deprecated and will not be exported" *
+                     " in the future, use `HypothesisCoding(pinv(contrasts))` instead.",
+                     :ContrastsCoding)
         check_contrasts_size(mat, levels)
         new(mat, base, levels)
     end

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -423,7 +423,7 @@ corresponding predictor, given as the weights given to the "cell mean" of each
 of the ``k`` values of the predictor.
 
 For instance, if we have a variable which has four levels A, B, C, and D, and we
-want to test the hypothesis that the difference between the average outcome for
+want to test the hypothesis that the difference between the average outcomes for
 levels A and B is different from zero, the corresponding row of the hypothesis
 matrix would be `[-1, 1, 0, 0]`.  Likewise, to test whether the difference
 between B and C is different from zero, the hypothesis vector would be `[0, -1,

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -370,7 +370,7 @@ end
 """
     SeqDiffCoding([base[, levels]])
 
-Codes each level in order to test "sequential difference" hypotheses, which
+Code each level in order to test "sequential difference" hypotheses, which
 compares each level to the level below it (starting with the second level).
 Specifically, the ``n``th predictor tests the hypothesis that the difference
 between levels ``n`` and ``n+1`` is zero.
@@ -414,11 +414,11 @@ end
 
 
 """
-    HypothesisCoding(hypotheses::Matrix[, levels]])
+    HypothesisCoding(hypotheses::Matrix[, levels])
 
 Specify how to code a categorical variable in terms of a *hypothesis matrix*.
 For a variable with ``k`` levels, this should be a ``k-1 \times k`` matrix.
-Each row of the hypothesis corresponds to the hypothesis tested by the
+Each row of the matrix corresponds to the hypothesis tested by the
 corresponding predictor, given as the weights given to the "cell mean" of each
 of the ``k`` values of the predictor.
 
@@ -447,7 +447,7 @@ julia> sdiff_contrasts = pinv(sdiff_hypothesis)
   0.25   0.5   0.75
 ```
 
-Which is what is produced by constructing a [`ContrastsMatrix`](@ref) from a
+The above matrix is what is produced by constructing a [`ContrastsMatrix`](@ref) from a
 `HypothesisCoding` instance:
 
 ```jldoctest hyp

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -418,7 +418,7 @@ end
 
 Specify how to code a categorical variable in terms of a *hypothesis matrix*.
 For a variable with ``k`` levels, this should be a ``k-1 \times k`` matrix.
-Each row of the matrix corresponds corresponds to a hypothesis about the mean
+Each row of the matrix corresponds to a hypothesis about the mean
 outcomes under each of the ``k`` levels of the predictor.  The entries in the
 row give the weights assigned to each of these ``k`` means, and the
 corresponding predictor in a regression model estimates the weighted sum of


### PR DESCRIPTION
`ContrastsCoding` is a footgun unless you really know what you're doing.
Hypothesis coding is a more natural way of specifying manual contrasts, since it
directly expresses differences between conditional means of levels in the matrix
(which is the pseudo-inverse of the contrasts matrix).  This PR introduces a
`HypothesisCoding <: AbstractContrasts` which is exported, and un-exports
`ContrastsCoding` (and adds a note in the docs/help text that points to
hypotheses)