### PR TITLE
Fix predict with confidence interval

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.5"
+version = "0.6.6"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"


### PR DESCRIPTION
DataFrames aren't a dependency anymore.

Fixes https://github.com/JuliaStats/StatsModels.jl/issues/159. Covered by tests at https://github.com/JuliaStats/GLM.jl/pull/335 (we should add tests with a dummy model type at some point).