### PR TITLE
Indexable model

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -196,3 +196,25 @@ function Base.show(io::IO, model::TableModels)
         end
     end
 end
+
+function getparams(model::TableModels, t)
+    m = model.mf.f.rhs.terms
+    i = 1
+    for x in m
+        if (t isa CategoricalTerm || t isa ContinuousTerm) &&
+           (x isa CategoricalTerm || x isa ContinuousTerm)
+            x.sym == t.sym && break
+        elseif t isa InteractionTerm && x isa InteractionTerm
+            xterms = map(s -> s.sym, x.terms)
+            tterms = map(s -> s.sym, t.terms)
+            xterms == tterms && break
+        elseif t isa InterceptTerm{true} && x isa InterceptTerm{true} 
+            break
+        else 
+            error("Not supported yet")
+        end
+        i += 1
+        
+    end
+    return (coefname = coefnames(model)[i], coef = coef(model)[i], stderror = stderror(model)[i])
+end

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -197,24 +197,35 @@ function Base.show(io::IO, model::TableModels)
     end
 end
 
-function getparams(model::TableModels, t)
+"""
+    getparams(model::TableModels, t::AbstractTerm)
+
+Returns a named tuple of parameters corresponding to `t`. 
+
+Examples: 
+
+julia> t = (y = rand(100), x = rand(100), b = rand(Bool, 100));
+julia> m = lm(@formula(y ~ x + x & b), t);
+julia> getparams(m, Term(:x))
+
+"""
+function getparams(model::TableModels, t::AbstractTerm)
     m = model.mf.f.rhs.terms
     i = 1
     for x in m
-        if (t isa CategoricalTerm || t isa ContinuousTerm) &&
-           (x isa CategoricalTerm || x isa ContinuousTerm)
-            x.sym == t.sym && break
-        elseif t isa InteractionTerm && x isa InteractionTerm
+        @show typeof(x)
+        if t isa InteractionTerm && x isa InteractionTerm
             xterms = map(s -> s.sym, x.terms)
             tterms = map(s -> s.sym, t.terms)
             xterms == tterms && break
         elseif t isa InterceptTerm{true} && x isa InterceptTerm{true} 
             break
+        elseif x isa CategoricalTerm || x isa ContinuousTerm
+            x.sym == t.sym && break
         else 
-            error("Not supported yet")
+            nothing
         end
         i += 1
-        
     end
     return (coefname = coefnames(model)[i], coef = coef(model)[i], stderror = stderror(model)[i])
 end


### PR DESCRIPTION
This is a very short PR that serves as a test for a feature that I think would be nice in StatsModels. It allows you to index a model by a `Term`. 

It is motivated by Stata functionality like ``_b[`var']`` which allows you to, get the `beta` coefficient for the column represented by `var`. This is really useful when making tables and graphs programatically. 

My approach is to take in a model and a `AbstractTerm`. Then check if the `AbstractTerm` matches, roughly, something in the model. If it does, match, it returns a `NamedTuple` with the coefficient name, coefficient, and the standard error.

```
julia> t = (y = rand(100), x = rand(100), b = rand(Bool, 100));
julia> m = lm(@formula(y ~ x + x & b), t);
julia> getparams(m, Term(:x)) 
```

Note that in the last line `Term(:x)` is not a `ContinuousTerm` or `CategoricalTerm`, I just match the `x.sym` paramter.