### PR TITLE
Fix tests with DataFrames 0.21

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+CategoricalArrays = "0.7"
 DataAPI = "1.1"
+DataFrames = "0.20, 0.21"
 DataStructures = "0.17.0"
 ShiftedArrays = "1.0.0"
 StatsBase = "0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32, 0.33"

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -160,7 +160,7 @@
                       y = repeat([:c, :d], inner = 2, outer = 2),
                       z = repeat([:e, :f], inner = 4))
         categorical!(d)
-        cs = Dict([Pair(name, EffectsCoding()) for name in names(d)])
+        cs = Dict([Symbol(name) => EffectsCoding() for name in names(d)])
         d.n = 1.:8
     
     


### PR DESCRIPTION
Keep support for 0.20 since it's very easy.
Add compatibility bounds to ensure this problem doesn't happen again.