### PR TITLE
bump patch version to 0.6.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.11"
+version = "0.6.12"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"


### PR DESCRIPTION
No breaking changes have been introduced since 0.6.11 was tagged (just merged 
#162 (new feature: lrtest), #179 (fix tests), and #181 (internal changes to how
contrast levels are accessed, which doesn't affect any existing code that relies
on `.levels` field of `AbstractContrasts`).