### PR TITLE
Bump CategoricalArrays to 0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,9 +14,9 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-CategoricalArrays = "0.7"
+CategoricalArrays = "0.8"
 DataAPI = "1.1"
-DataFrames = "0.20, 0.21"
+DataFrames = "0.21"
 DataStructures = "0.17.0, 0.18"
 Distributions = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22, 0.23"
 ShiftedArrays = "1.0.0"


### PR DESCRIPTION
We claim to support DataFrames 0.21, but it wasn't actually used since we didn't support CategoricalArrays 0.8.