### PR TITLE
Add string method for `term`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.13"
+version = "0.6.14"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -299,10 +299,10 @@ Predictors:
     long as the packages have [implemented support for them](@ref extend-runtime).
 
 The [`term`](@ref) function constructs a term of the appropriate type from
-symbols and numbers, which makes it easy to work with collections of mixed type:
+symbols, strings and numbers, which makes it easy to work with collections of mixed type:
 
 ```jldoctest 1
-julia> ts = term.((1, :a, :b))
+julia> ts = term.((1, :a, "b"))
 1
 a(unknown)
 b(unknown)

--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -299,7 +299,8 @@ Predictors:
     long as the packages have [implemented support for them](@ref extend-runtime).
 
 The [`term`](@ref) function constructs a term of the appropriate type from
-symbols, strings and numbers, which makes it easy to work with collections of mixed type:
+symbols or strings (`Term`) and numbers (`ConstantTerm`), which makes it easy to 
+work with collections of mixed type:
 
 ```jldoctest 1
 julia> ts = term.((1, :a, "b"))

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -580,12 +580,13 @@ hasresponse(t::FormulaTerm) =
     term(x)
 
 Wrap argument in an appropriate `AbstractTerm` type: `Symbol`s become `Term`s,
-and `Number`s become `ConstantTerm`s.  Any `AbstractTerm`s are unchanged.
+and `Number`s become `ConstantTerm`s.  Any `AbstractTerm`s are unchanged. `AbstractString`s
+are converted to symbols before wrapping.
 
 # Example
 
 ```jldoctest
-julia> ts = term.((1, :a, :b))
+julia> ts = term.((1, :a, "b"))
 1
 a(unknown)
 b(unknown)

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -579,7 +579,7 @@ hasresponse(t::FormulaTerm) =
 """
     term(x)
 
-Wrap argument in an appropriate `AbstractTerm` type: `Symbol`s become `Term`s,
+Wrap argument in an appropriate `AbstractTerm` type: `Symbol`s and `AbstractString`s become `Term`s,
 and `Number`s become `ConstantTerm`s.  Any `AbstractTerm`s are unchanged. `AbstractString`s
 are converted to symbols before wrapping.
 

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -596,4 +596,5 @@ Tuple{ConstantTerm{Int64},Term,Term}
 """
 term(n::Number) = ConstantTerm(n)
 term(s::Symbol) = Term(s)
+term(s::AbstractString) = term(Symbol(s))
 term(t::AbstractTerm) = t

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -18,6 +18,8 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
 
     @testset "concrete_term" begin
         t = term(:aaa)
+        ts = term("aaa")
+        @test t == ts
         @test string(t) == "aaa"
         @test mimestring(t) == "aaa(unknown)"
 


### PR DESCRIPTION
As discussed on Slack, this makes it easier to create `Term` objects from `DataFrame` columns, as `names(df)` now returns strings. 