### PR TITLE
Switch integration to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StatsModels
 
-[![Build Status](https://travis-ci.org/JuliaStats/StatsModels.jl.svg?branch=master)](https://travis-ci.org/JuliaStats/StatsModels.jl)
+[![Build Status](https://travis-ci.com/JuliaStats/StatsModels.jl.svg?branch=master)](https://travis-ci.com/JuliaStats/StatsModels.jl)
 [![codecov](https://codecov.io/gh/JuliaStats/StatsModels.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/JuliaStats/StatsModels.jl)
 
 Basic functionality for specifying, fitting, and evaluating statistical models


### PR DESCRIPTION
Only change is to badge at this point; migration is done on the Travis end
already.