### PR TITLE
use trigger to run tagbot instead of cron

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,6 +1,6 @@
 name: TagBot
 on:
-  issue_comment:  # THIS BIT IS NEW
+  issue_comment:
     types:
       - created
 jobs:

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,9 +1,11 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:  # THIS BIT IS NEW
+    types:
+      - created
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1


### PR DESCRIPTION
To avoid disabled workflows after 60 days of inactivity, and to get instant
tagging with merged registrator PRs.  Based on [discourse
post](https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249).