### PR TITLE
fix missing methods for +

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.15"
+version = "0.6.16"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -400,9 +400,10 @@ Base.:&(terms::AbstractTerm...) = InteractionTerm(terms)
 Base.:&(term::AbstractTerm) = term
 Base.:&(it::InteractionTerm, terms::AbstractTerm...) = InteractionTerm((it.terms..., terms...))
 
-Base.:+(terms::AbstractTerm...) = (unique(terms)..., )
-Base.:+(as::TupleTerm, b::AbstractTerm) = (as..., b)
-Base.:+(a::AbstractTerm, bs::TupleTerm) = (a, bs...)
+Base.:+(a::AbstractTerm, b::AbstractTerm) = a==b ? a : (a, b)
+Base.:+(as::TupleTerm, b::AbstractTerm) = b in as ? as : (as..., b)
+Base.:+(a::AbstractTerm, bs::TupleTerm) = a in bs ? bs : (a, bs...)
+Base.:+(as::TupleTerm, bs::TupleTerm) = (union(as, bs)..., )
 
 ################################################################################
 # evaluating terms with data to generate model matrix entries

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -75,8 +75,15 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
         @test string(a & b) == "$a & $b"
         @test mimestring(a & b) == "a(unknown) & b(unknown)"
         c = term(:c)
-        @test (a+b)+c == (a,b,c)
-        @test a+(b+c) == (a,b,c)
+        ab = a+b
+        bc = b+c
+        abc = a+b+c
+        @test ab+c == abc
+        @test ab+a == ab
+        @test a+bc == abc
+        @test b+ab == ab
+        @test ab+ab == ab
+        @test ab+bc == abc
     end
 
     @testset "expand nested tuples of terms during apply_schema" begin


### PR DESCRIPTION
Fills in some missing methods for adding collections of terms with `+`, and
tests which target those (formerly) missing methods.

Fixes JuliaStats/MixedModels.jl#452