### PR TITLE
Equality of FunctionTerms

### DIFF
--- a/src/terms.jl
+++ b/src/terms.jl
@@ -127,6 +127,8 @@ FunctionTerm(forig::Fo, fanon::Fa, names::NTuple{N,Symbol},
     FunctionTerm{Fo, Fa, names}(forig, fanon, exorig, args_parsed)
 width(::FunctionTerm) = 1
 
+Base.:(==)(a::FunctionTerm, b::FunctionTerm) = a.forig == b.forig && a.exorig == b.exorig
+
 """
     InteractionTerm{Ts} <: AbstractTerm
 

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -89,8 +89,10 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
     @testset "uniqueness of FunctionTerms" begin
         f1 = @formula(y ~ lag(x,1) + lag(x,1))
         f2 = @formula(y ~ lag(x,1))
+        f3 = @formula(y ~ lag(x,1) + lag(x,2))
 
         @test f1.rhs == f2.rhs
+        @test f1.rhs != f3.rhs
 
         ## addition of two identical function terms
         @test f2.rhs + f2.rhs == f2.rhs

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -86,6 +86,16 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
         @test ab+bc == abc
     end
 
+    @testset "uniqueness of FunctionTerms" begin
+        f1 = @formula(y ~ lag(x,1) + lag(x,1))
+        f2 = @formula(y ~ lag(x,1))
+
+        @test f1.rhs == f2.rhs
+
+        ## addition of two identical function terms
+        @test f2.rhs + f2.rhs == f2.rhs
+    end
+
     @testset "expand nested tuples of terms during apply_schema" begin
         sch = schema((a=rand(10), b=rand(10), c=rand(10)))
 


### PR DESCRIPTION
Fixes #204 by adding a method to check equality of function terms based only on
the type of the original function and the expression (not the generated
anonymous function, which will be different even for identical expressions from
identical environments).