### PR TITLE
add modelmatrix method for TableRegressionModel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.19"
+version = "0.6.20"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -34,7 +34,7 @@ end
 
 """
 Wrapper for a `StatisticalModel` that has been fit from a `@formula` and tabular
-data.  
+data.
 
 Most functions from the StatsBase API are simply delegated to the wrapped model,
 with the exception of functions like `fit`, `predict`, and `coefnames` where the
@@ -54,7 +54,7 @@ end
 
 """
 Wrapper for a `RegressionModel` that has been fit from a `@formula` and tabular
-data.  
+data.
 
 Most functions from the StatsBase API are simply delegated to the wrapped model,
 with the exception of functions like `fit`, `predict`, and `coefnames` where the
@@ -78,7 +78,7 @@ for (modeltype, dfmodeltype) in ((:StatisticalModel, TableStatisticalModel),
         function StatsBase.fit(::Type{T}, f::FormulaTerm, data, args...;
                                contrasts::Dict{Symbol,<:Any} = Dict{Symbol,Any}(),
                                kwargs...) where T<:$modeltype
-                               
+
             Tables.istable(data) || throw(ArgumentError("expected data in a Table, got $(typeof(data))"))
             cols = columntable(data)
 
@@ -97,7 +97,7 @@ for (modeltype, dfmodeltype) in ((:StatisticalModel, TableStatisticalModel),
 end
 
 @doc """
-    fit(Mod::Type{<:StatisticalModel}, f::FormulaTerm, data, args...; 
+    fit(Mod::Type{<:StatisticalModel}, f::FormulaTerm, data, args...;
         contrasts::Dict{Symbol}, kwargs...)
 
 Convert tabular data into a numeric response vector and predictor matrix using
@@ -130,6 +130,10 @@ StatsBase.r2(mm::TableRegressionModel) = r2(mm.model)
 StatsBase.adjr2(mm::TableRegressionModel) = adjr2(mm.model)
 StatsBase.r2(mm::TableRegressionModel, variant::Symbol) = r2(mm.model, variant)
 StatsBase.adjr2(mm::TableRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
+
+# delegate to the wrapped model instead of returning the model matrix directly
+# so that the types are the same
+StatsBase.modelmatrix(trmod::TableRegressionModel) = modelmatrix(trmod.model)
 
 function _return_predictions(T, yp::AbstractVector, nonmissings, len)
     out = Vector{Union{eltype(yp),Missing}}(missing, len)

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -120,7 +120,8 @@ const TableModels = Union{TableStatisticalModel, TableRegressionModel}
                              StatsBase.loglikelihood, StatsBase.nullloglikelihood,
                              StatsBase.dof, StatsBase.dof_residual, StatsBase.nobs,
                              StatsBase.stderror, StatsBase.vcov]
-@delegate TableRegressionModel.model [StatsBase.residuals, StatsBase.response,
+@delegate TableRegressionModel.model [StatsBase.modelmatrix,
+                                      StatsBase.residuals, StatsBase.response,
                                       StatsBase.predict, StatsBase.predict!]
 StatsBase.predict(m::TableRegressionModel, new_x::AbstractMatrix; kwargs...) =
     predict(m.model, new_x; kwargs...)
@@ -130,10 +131,6 @@ StatsBase.r2(mm::TableRegressionModel) = r2(mm.model)
 StatsBase.adjr2(mm::TableRegressionModel) = adjr2(mm.model)
 StatsBase.r2(mm::TableRegressionModel, variant::Symbol) = r2(mm.model, variant)
 StatsBase.adjr2(mm::TableRegressionModel, variant::Symbol) = adjr2(mm.model, variant)
-
-# delegate to the wrapped model instead of returning the model matrix directly
-# so that the types are the same
-StatsBase.modelmatrix(trmod::TableRegressionModel) = modelmatrix(trmod.model)
 
 function _return_predictions(T, yp::AbstractVector, nonmissings, len)
     out = Vector{Union{eltype(yp),Missing}}(missing, len)


### PR DESCRIPTION
This delegates to the inner model for return value consistency -- `modelmatrix(::RegressionModel)` is defined in StatsBase and `TableRegressionModel` wraps `RegressionModel`. Users who want the fancy `ModelMatrix` and are specified on `TableRegressionModel` can access that field directly.

Sorry about the whitespace changes.