### PR TITLE
Fix empty tuple piracy

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.20"
+version = "0.6.21"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -1,6 +1,6 @@
 abstract type AbstractTerm end
-const TermOrTerms = Union{AbstractTerm, NTuple{N, AbstractTerm} where N}
-const TupleTerm = NTuple{N, TermOrTerms} where N
+const TermOrTerms = Union{AbstractTerm, Tuple{AbstractTerm, Vararg{AbstractTerm}}}
+const TupleTerm = Tuple{TermOrTerms, Vararg{TermOrTerms}}
 
 width(::T) where {T<:AbstractTerm} =
     throw(ArgumentError("terms of type $T have undefined width"))

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -203,6 +203,11 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
         @test_throws MethodError () & a
         @test_throws MethodError a ~ ()
         @test_throws MethodError () ~ a
+
+        # show methods of empty tuples preserved
+        @test "$(())" == "()"
+        @test "$((a,b))" == "a + b"
+        @test "$((a, ()))" == "(a, ())"
     end
 
 end

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -173,4 +173,36 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
 
     end
 
+    @testset "Tuple terms" begin
+        using StatsModels: TermOrTerms, TupleTerm, Term
+        a, b, c = Term.((:a, :b, :c))
+
+        # TermOrTerms - one or more AbstractTerms (if more, a tuple)
+        # empty tuples are never terms
+        @test !(() isa TermOrTerms)
+        @test (a, ) isa TermOrTerms
+        @test (a, b) isa TermOrTerms
+        @test (a, b, a&b) isa TermOrTerms
+        @test !(((), a) isa TermOrTerms)
+        # can't contain further tuples
+        @test !((a, (a,), b) isa TermOrTerms)
+
+        # a tuple of AbstractTerms OR Tuples of one or more terms
+        # empty tuples are never terms
+        @test !(() isa TupleTerm)
+        @test (a, ) isa TupleTerm
+        @test (a, b) isa TupleTerm
+        @test (a, b, a&b) isa TupleTerm
+        @test !(((), a) isa TupleTerm)
+        @test (((a,), a) isa TupleTerm)
+
+        # no methods for operators on term and empty tuple (=no type piracy)
+        @test_throws MethodError a + ()
+        @test_throws MethodError () + a
+        @test_throws MethodError a & ()
+        @test_throws MethodError () & a
+        @test_throws MethodError a ~ ()
+        @test_throws MethodError () ~ a
+    end
+
 end


### PR DESCRIPTION
Fixes #213

The type aliases for tuples of terms used `NTuple` which included empty
tuples.  This changes those aliases to use `Tuple{T, Vararg{T}}` instead, which
enforces that there's at least one `T` (`AbstractTerm` etc.) in the tuple.