### PR TITLE
Deprecate un-used `base=` kwarg for `SeqDiffCoding`

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -453,7 +453,7 @@ mutable struct SeqDiffCoding <: AbstractContrasts
 end
 function SeqDiffCoding(; base=nothing, levels::Union{AbstractVector,Nothing}=nothing)
     if base !== nothing
-        Base.depwarn("`base=` kwarg for `SeqDiffCoding` is deprecated. " *
+        Base.depwarn("`base=` kwarg for `SeqDiffCoding` has no effect and is deprecated. " *
                      "Specify full order of levels using `levels=` instead",
                      :SeqDiffCoding)
     end

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -316,7 +316,7 @@
         @test baselevel(c) == levs[1]
         @test levels(c) == levs
 
-        c = @test_log ((:warn,
+        c = @test_logs((:warn,
                         "`base=` kwarg for `SeqDiffCoding` is deprecated. " *
                         "Specify full order of levels using `levels=` instead"),
                        SeqDiffCoding(base=base))

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -289,8 +289,8 @@
         using StatsModels: baselevel, FullDummyCoding, ContrastsCoding
 
         levs = [:a, :b, :c, :d]
-        base = [:a]
-        for C in [DummyCoding, EffectsCoding, SeqDiffCoding, HelmertCoding]
+        base = [:c]
+        for C in [DummyCoding, EffectsCoding, HelmertCoding]
             c = C()
             @test levels(c) == nothing
             @test baselevel(c) == nothing
@@ -307,6 +307,25 @@
             @test levels(c) == levs
             @test baselevel(c) == base
         end
+
+        c = SeqDiffCoding()
+        @test baselevel(c) == nothing
+        @test levels(c) == nothing
+
+        c = SeqDiffCoding(levels=levs)
+        @test baselevel(c) == levs[1]
+        @test levels(c) == levs
+
+        c = @test_log ((:warn,
+                        "`base=` kwarg for `SeqDiffCoding` is deprecated. " *
+                        "Specify full order of levels using `levels=` instead"),
+                       SeqDiffCoding(base=base))
+        @test baselevel(c) == nothing
+        @test levels(c) == nothing
+
+        c = SeqDiffCoding(base=base, levels=levs)
+        @test baselevel(c) == levs[1]
+        @test levels(c) == levs
 
         c = FullDummyCoding()
         @test baselevel(c) == nothing

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -317,7 +317,7 @@
         @test levels(c) == levs
 
         c = @test_logs((:warn,
-                        "`base=` kwarg for `SeqDiffCoding` is deprecated. " *
+                        "`base=` kwarg for `SeqDiffCoding` has no effect and is deprecated. " *
                         "Specify full order of levels using `levels=` instead"),
                        SeqDiffCoding(base=base))
         @test baselevel(c) == nothing


### PR DESCRIPTION
`SeqDiffCoding` has an un-used base kwarg and field.  This can cause confusion (#237 ), so I propose deprecating and eventually removing the kwarg.  This PR removes the internal field and adds a deprecation warning.