### PR TITLE
relax some checks on eltypes for contrasts and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -27,9 +27,10 @@ julia = "1"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CategoricalArrays", "DataFrames", "Statistics", "Test"]
+test = ["CategoricalArrays", "CSV", "DataFrames", "Statistics", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
+CSV = "0.8, 0.9.10"
 DataAPI = "1.1"
 DataFrames = "1"
 DataStructures = "0.17, 0.18"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.26"
+version = "0.6.27"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
@@ -16,7 +16,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 CategoricalArrays = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
-CSV = "0.8, 0.9.10"
 DataAPI = "1.1"
 DataFrames = "1"
 DataStructures = "0.17, 0.18"
@@ -24,14 +23,15 @@ ShiftedArrays = "1"
 StatsBase = "0.33.5"
 StatsFuns = "0.9"
 Tables = "0.2, 1"
-julia = "1"
+WeakRefStrings = "1"
+julia = "1.6"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["CategoricalArrays", "CSV", "DataFrames", "Statistics", "Test"]
+test = ["CategoricalArrays", "DataFrames", "Statistics", "Test", "WeakRefStrings"]

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -357,18 +357,13 @@
     end
 
     @testset "other string types" begin
-        using CSV
+        using WeakRefStrings
 
         using StatsModels: ContrastsMatrix
         using DataAPI: levels
 
         x = ["a", "b", "c", "a", "a", "b"]
-        io = IOBuffer()
-        tab = CSV.write(io, (; x=x, ))
-        seekstart(io)
-        x1 = Tables.columntable(CSV.File(io)).x
-        # this doesn't work w/ Julia < 1.3 because of WeakRefStrings compat
-        # x1 = WeakRefStrings.String1.(x)
+        x1 = WeakRefStrings.String1.(x)
         x1_levs = levels(x1)
 
         @test issetequal(x, x1)

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -357,6 +357,8 @@
     end
 
     @testset "other string types" begin
+        using CSV
+
         using StatsModels: ContrastsMatrix
         using DataAPI: levels
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -376,7 +376,7 @@
         c1 = ContrastsMatrix(DummyCoding(), x1_levs)
         c = ContrastsMatrix(DummyCoding(levels=["a", "b", "c"]), x1_levs)
         @test c == c1
-        @test eltype(c.levels) == eltype(c1.levels) != eltype(c.contrasts.levels)
+        @test eltype(c.levels) == eltype(c1.levels)
 
         @test_throws ArgumentError ContrastsMatrix(DummyCoding(levels=[1, 2, 3]), x1_levs)
     end


### PR DESCRIPTION
To maintain compat with Julia 1.0, I had to write the tests using CSV to round trip some strings...that should produce `StringN` types for versions where that's possible and do something reasonable otherwise.

fixes #236