### PR TITLE
Fix missing `coeftable` method detection.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         version:
           - '1.0'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ShiftedArrays = "1"
 StatsBase = "0.33.5"
 StatsFuns = "0.9"
 Tables = "0.2, 1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.6.28"
+version = "0.6.29"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -132,7 +132,7 @@ const TableModels = Union{TableStatisticalModel, TableRegressionModel}
                              StatsBase.stderror, StatsBase.vcov, StatsBase.fitted]
 @delegate TableRegressionModel.model [StatsBase.modelmatrix,
                                       StatsBase.residuals, StatsBase.response,
-                                      StatsBase.predict, StatsBase.predict!, 
+                                      StatsBase.predict, StatsBase.predict!,
                                       StatsBase.cooksdistance]
 StatsBase.predict(m::TableRegressionModel, new_x::AbstractMatrix; kwargs...) =
     predict(m.model, new_x; kwargs...)
@@ -195,16 +195,15 @@ end
 
 # show function that delegates to coeftable
 function Base.show(io::IO, model::TableModels)
+    println(io, typeof(model))
+    println(io)
+    println(io, model.mf.f)
+    println(io)
     try
-        ct = coeftable(model)
-        println(io, typeof(model))
-        println(io)
-        println(io, model.mf.f)
-        println(io)
         println(io,"Coefficients:")
-        show(io, ct)
+        show(io, coeftable(model))
     catch e
-        if isa(e, ErrorException) && occursin("coeftable is not defined", e.msg)
+        if isa(e, MethodError) || isa(e, ErrorException) && occursin("coeftable is not defined", e.msg)
             show(io, model.model)
         else
             rethrow(e)

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -106,7 +106,6 @@ end
 StatsBase.fit(::Type{DummyModTwo}, ::Matrix, ::Vector) = DummyModTwo("hello!")
 Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
 
-
 @testset "stat model types" begin
 
     ## Test fitting
@@ -230,8 +229,8 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
     @test predict(m4, d[2:4, :]) == predict(m4)[2:4]
 
     m2 = fit(DummyModTwo, f, d)
+    # make sure show() still works when there is no coeftable method
     show(io, m2)
-
 end
 
 @testset "lrtest" begin


### PR DESCRIPTION
I think this is the result of some of the re-organization going on with StatsBase/StatsAPI.

Bottom line is that `coeftable` used to have a default method with `error`, but this is now missing and so we get a `MethodError`.