### PR TITLE
fix bug in `hasintercept`

### DIFF
--- a/src/terms.jl
+++ b/src/terms.jl
@@ -583,14 +583,17 @@ StatsBase.coefnames(t::InteractionTerm) =
 # old Terms features:
 
 hasintercept(f::FormulaTerm) = hasintercept(f.rhs)
-hasintercept(t::TermOrTerms) =
-    InterceptTerm{true}() ∈ terms(t) ||
-    ConstantTerm(1) ∈ terms(t)
+hasintercept(t::AbstractTerm) = t == InterceptTerm{true}() || t == ConstantTerm(1)
+hasintercept(t::TupleTerm) = any(hasintercept, t)
+hasintercept(t::MatrixTerm) = hasintercept(t.terms)
+
 omitsintercept(f::FormulaTerm) = omitsintercept(f.rhs)
-omitsintercept(t::TermOrTerms) =
-    InterceptTerm{false}() ∈ terms(t) ||
-    ConstantTerm(0) ∈ terms(t) ||
-    ConstantTerm(-1) ∈ terms(t)
+omitsintercept(t::AbstractTerm) =
+    t == InterceptTerm{false}() ||
+    t == ConstantTerm(0) ||
+    t == ConstantTerm(-1)
+omitsintercept(t::TupleTerm) = any(omitsintercept, t)
+omitsintercept(t::MatrixTerm) = omitsintercept(t.terms)
 
 hasresponse(t) = false
 hasresponse(t::FormulaTerm) =

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -161,6 +161,7 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
         no_responses = [term(0), InterceptTerm{false}()]
 
         has_intercepts = [term(1), InterceptTerm{true}()]
+        no_intercepts = [term(:x), FunctionTerm(log, [term(1), term(:x)], :(log(1+x)))]
         omits_intercepts = [term(0), term(-1), InterceptTerm{false}()]
 
         using StatsModels: hasresponse, hasintercept, omitsintercept
@@ -206,6 +207,26 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
             @test !hasresponse(lhs ~ rhs + a)
             @test !hasintercept(lhs ~ rhs + a)
             @test omitsintercept(lhs ~ rhs + a)
+        end
+
+        for lhs in has_responses, rhs in no_intercepts
+            @test hasresponse(lhs ~ rhs)
+            @test !hasintercept(lhs ~ rhs)
+            @test !omitsintercept(lhs ~ rhs)
+
+            @test hasresponse(lhs ~ rhs + a)
+            @test !hasintercept(lhs ~ rhs + a)
+            @test !omitsintercept(lhs ~ rhs + a)
+        end
+
+        for lhs in no_responses, rhs in no_intercepts
+            @test !hasresponse(lhs ~ rhs)
+            @test !hasintercept(lhs ~ rhs)
+            @test !omitsintercept(lhs ~ rhs)
+
+            @test !hasresponse(lhs ~ rhs + a)
+            @test !hasintercept(lhs ~ rhs + a)
+            @test !omitsintercept(lhs ~ rhs + a)
         end
 
     end


### PR DESCRIPTION
Right now `hasintercept` uses `terms` to get a list of all terms in a formula RHS to check for an intercept term there.  That's not appropriate because it recurses into `FunctionTerm`s which now can include `ConstantTerm(1)` and hence triggers the "has intercept" test.