### PR TITLE
remove unneeded Compat dep and add Aqua tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+Aqua = "0.6"
 CategoricalArrays = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.10"
 DataAPI = "1.1"
 DataFrames = "1"
@@ -27,6 +28,7 @@ WeakRefStrings = "1"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -34,4 +36,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [targets]
-test = ["CategoricalArrays", "DataFrames", "Statistics", "Test", "WeakRefStrings"]
+test = ["Aqua", "CategoricalArrays", "DataFrames", "Statistics", "Test", "WeakRefStrings"]

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
 version = "0.7.0"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using Aqua
 using LinearAlgebra
 using SparseArrays
 
@@ -23,6 +24,10 @@ my_tests = ["ambiguity.jl",
             "protect.jl"]
 
 @testset "StatsModels" begin
+    @testset "aqua" begin
+        Aqua.test_all(StatsModels; ambiguities=false)
+    end
+
     for tf in my_tests
         include(tf)
     end


### PR DESCRIPTION
registering 0.7 failed because Compat is listed as a dependency without compat bounds; it's not needed so can be removed.  Aqua tests would have caught this earlier so I've added those too.