### PR TITLE
fix tests on nightly

### DIFF
--- a/src/schema.jl
+++ b/src/schema.jl
@@ -215,6 +215,11 @@ function concrete_term(t::Term, xs::AbstractArray, contrasts::AbstractContrasts)
     CategoricalTerm(t.sym, contrmat)
 end
 
+# this catches early when someone provides `:x => DummyCoding` as a hint
+function concrete_term(t::Term, xs::AbstractArray, ::Type{T}) where {T<:AbstractContrasts}
+    throw(ArgumentError("contrast types must be instantiated (use $T() instead of $T)"))
+end
+
 """
     apply_schema(t, schema::StatsModels.Schema[, Mod::Type = Nothing])
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -198,7 +198,7 @@
 
     # contrasts types must be instantiated (should throw ArgumentError, currently
     # MethodError on apply_schema)
-    @test_broken setcontrasts!(mf, x = DummyCoding)
+    @test_throws ArgumentError setcontrasts!(mf, x = DummyCoding)
 
     @testset "hypothesis coding" begin
 

--- a/test/formula.jl
+++ b/test/formula.jl
@@ -118,8 +118,9 @@
         @formula(foo ~ bar + baz)
 
     # drop_term no longer checks for whether term is found...
-    @test_broken drop_term(@formula(foo ~ bar + baz), term(0))
-    @test_broken drop_term(@formula(foo ~ bar + baz), term(:boz))
+    f = @formula(foo ~ bar + baz)
+    @test drop_term(f, term(0)) == f
+    @test drop_term(f, term(:boz)) == f
 
     form = @formula(foo ~ 1 + bar + baz)
     @test form == @formula(foo ~ 1 + bar + baz)


### PR DESCRIPTION
It seems that nightly changes the behavior of `@test_broken` to error if the returned value is not a boolean or no error is thrown.  We had three tests with behavior like this: two where the behavior of `drop_term` changed from previous (pre 0.6) version to not check whether the term was present at all (seems fine and no one has complained about it in 4 years so it's okay to change the semantics), and another where a fix to one issue caused a previously erroring path to no longer error.  I restored the error with a specific method to catch the footgun of passing `:x => DummyCoding` (instead of `:x => DummyCoding()`) earlier.

This doesn't need to block 0.7 release.