### PR TITLE
fix `degree` for `ConstantTerm`/`InterceptTerm`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/terms.jl
+++ b/src/terms.jl
@@ -414,6 +414,8 @@ Base.:*(a::TermOrTerms, b::TermOrTerms) = a + b + a&b
 cleanup(terms::TupleTerm) = Tuple(sort!(unique!(collect(terms)), by=degree))
 cleanup(x) = x
 
+degree(::ConstantTerm) = 0
+degree(::InterceptTerm) = 0
 degree(::AbstractTerm) = 1
 degree(t::InteractionTerm) = mapreduce(degree, +, t.terms)
 # dirty hack, move to MixedModels.jl

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -274,4 +274,14 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
         @test_throws ArgumentError concrete_term(term(:not_there), t )
     end
 
+    @testset "sort by degree in ~" begin
+        one, a, b = term.([1, :a, :b])
+
+        @test a + one == (a, one)
+        @test (a ~ a + one) == (a ~ one + a)
+
+        @test a & b + one + a == (a & b, one, a)
+        @test (a ~ a & b + one + a) == (a ~ one + a + a & b)
+    end
+
 end

--- a/test/terms.jl
+++ b/test/terms.jl
@@ -276,12 +276,13 @@ StatsModels.apply_schema(mt::MultiTerm, sch::StatsModels.Schema, Mod::Type) =
 
     @testset "sort by degree in ~" begin
         one, a, b = term.([1, :a, :b])
+        for zero_deg in [one, InterceptTerm{true}(), InterceptTerm{false}()]
+            @test a + zero_deg == (a, zero_deg)
+            @test (a ~ a + zero_deg) == (a ~ zero_deg + a)
 
-        @test a + one == (a, one)
-        @test (a ~ a + one) == (a ~ one + a)
-
-        @test a & b + one + a == (a & b, one, a)
-        @test (a ~ a & b + one + a) == (a ~ one + a + a & b)
+            @test a & b + zero_deg + a == (a & b, zero_deg, a)
+            @test (a ~ a & b + zero_deg + a) == (a ~ zero_deg + a + a & b)
+        end
     end
 
 end


### PR DESCRIPTION
This was an oversight in #183, fixes #286 