### PR TITLE
use released GLM in docs now

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.8'
-      - run: julia --project=docs -e 'using Pkg; pkg"add GLM#dfk/statsmodels-7"'
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-docdeploy@latest
         env:

--- a/docs/src/formula.md
+++ b/docs/src/formula.md
@@ -220,7 +220,7 @@ julia> using GLM
 
 
 julia> lm(@formula(log(y) ~ 1 + a + b), df)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 :(log(y)) ~ 1 + a + b
 
@@ -236,7 +236,7 @@ b            -1.63199      1.12678   -1.45    0.1977  -4.38911    1.12513
 julia> df.log_y = log.(df.y);
 
 julia> lm(@formula(log_y ~ 1 + a + b), df)            # equivalent
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 log_y ~ 1 + a + b
 
@@ -368,7 +368,7 @@ julia> response(f, df)
  -2.980055366491228
  
 julia> lm(f, df)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 :(log(y)) ~ 1 + a + b
 
@@ -412,7 +412,7 @@ julia> ϵ = randn(rng, 100)*0.1;
 julia> data.y = X*β_true .+ ϵ;
 
 julia> mod = fit(LinearModel, @formula(y ~ 1 + a*b), data)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 y ~ 1 + a + b + a & b
 

--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -513,7 +513,7 @@ julia> sim_dat = DataFrame(a=rand(rng, 100).-0.5, b=randn(rng, 100).-0.5);
 julia> sim_dat.y = randn(rng, 100) .+ 1 .+ 2*sim_dat.a .+ 3*sim_dat.b.^2;
 
 julia> fit(LinearModel, @formula(y ~ 1 + poly(a,2) + poly(b,2)), sim_dat)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 y ~ 1 + poly(a, 2) + poly(b, 2)
 
@@ -622,7 +622,7 @@ Predictors:
   poly(b, 2)
 
 julia> fit(LinearModel, poly_formula, sim_dat)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 y ~ 1 + poly(a, 2) + poly(b, 2)
 
@@ -729,7 +729,7 @@ julia> sim_dat = DataFrame(b=randn(rng, 100));
 julia> sim_dat.y = randn(rng, 100) .+ 1 .+ 2*sim_dat.b .+ 3*sim_dat.b.^2;
 
 julia> fit(LinearModel, @formula(y ~ 1 + poly(b,2)), sim_dat)
-LinearModel
+StatsModels.TableRegressionModel{LinearModel{GLM.LmResp{Vector{Float64}}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 y ~ 1 + :(poly(b, 2))
 
@@ -742,7 +742,7 @@ poly(b, 2)   2.95861    0.174347  16.97    <1e-30   2.61262     3.30459
 ───────────────────────────────────────────────────────────────────────
 
 julia> fit(GeneralizedLinearModel, @formula(y ~ 1 + poly(b,2)), sim_dat, Normal())
-GeneralizedLinearModel
+StatsModels.TableRegressionModel{GeneralizedLinearModel{GLM.GlmResp{Vector{Float64}, Normal{Float64}, IdentityLink}, GLM.DensePredChol{Float64, LinearAlgebra.CholeskyPivoted{Float64, Matrix{Float64}, Vector{Int64}}}}, Matrix{Float64}}
 
 y ~ 1 + poly(b, 2)
 


### PR DESCRIPTION
Ultimately we want to remove GLM-based things from the docs since it means we can't build docs with GLM-breaking changes, but for now this will allow docs to build.