### PR TITLE
make `InterceptTerm`s generate `Bool`s to avoid unnecessary promotion of other columns

### DIFF
--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -409,6 +409,10 @@
         y, x = modelcols(apply_schema(f, schema(d)), d)
         @test eltype(y) == eltype(x) == Float32
 
+        f0 = @formula(y ~ 0 + x + log(x) * z)
+        y, x = modelcols(apply_schema(f0, schema(d)), d)
+        @test eltype(y) == eltype(x) == Float32
+
         contr = DummyCoding(; base=4, levels=1:4)
         d = (; y=rand(Float32, 4), x=rand(Float32, 4), z=[1:4; ])
 

--- a/test/modelmatrix.jl
+++ b/test/modelmatrix.jl
@@ -402,5 +402,27 @@
         f = apply_schema(@formula(0 ~ a&b&c), schema(t))
         @test vec(modelcols(f.rhs, t)) == modelcols.(Ref(f.rhs), Tables.rowtable(t))
     end
+
+    @testset "#293 conversion of Float32s" begin
+        d = (; y=rand(Float32, 4), x=rand(Float32, 4), z=[1:4; ])
+        f = @formula(y ~ 1 + x + log(x) * z)
+        y, x = modelcols(apply_schema(f, schema(d)), d)
+        @test eltype(y) == eltype(x) == Float32
+
+        contr = DummyCoding(; base=4, levels=1:4)
+        d = (; y=rand(Float32, 4), x=rand(Float32, 4), z=[1:4; ])
+
+        # currently this is the best way to construct contrasts with Float32s...
+        dummy_cmat = Float32[1 0 0
+                             0 1 0
+                             0 0 1
+                             0 0 0]
+        contr = StatsModels.ContrastsCoding(dummy_cmat, [1:4;])
+
+        sch = schema(f, d, Dict(:z => contr))
+        y, x = modelcols(apply_schema(f, sch), d)
+        @test size(x) == (4, 1 + 1 + 1 + 3 + 3)
+        @test eltype(x) == eltype(y) == Float32
+    end
     
 end


### PR DESCRIPTION
This is one possible fix for #293.  As described in that thread, the bottleneck here is actually that `InterceptTerm`s generate `Array{Float64}`s, which then get `hcat` with other columns and promote them to Float64.  With this change, normal julia promotion rules apply, and values will only be promoted as needed.

First adding tests to confirm that this behavior is currently broken, then will push teh fix and open for review when CI is green.