### PR TITLE
Fix coeftable when passing level keyword argument

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -185,7 +185,7 @@ StatsAPI.coefnames(model::TableModels) = coefnames(model.mf)
 
 # coeftable implementation
 function StatsAPI.coeftable(model::TableModels; kwargs...)
-    ct = coeftable(model.model, kwargs...)
+    ct = coeftable(model.model; kwargs...)
     cfnames = coefnames(model.mf)
     if length(ct.rownms) == length(cfnames)
         ct.rownms = cfnames

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -12,7 +12,7 @@ StatsAPI.fit(::Type{DummyMod}, x::Matrix, y::Vector) =
     DummyMod(collect(1:size(x, 2)), x, y)
 StatsAPI.response(mod::DummyMod) = mod.y
 ## dumb coeftable: just prints the "beta" values
-StatsAPI.coeftable(mod::DummyMod) =
+StatsAPI.coeftable(mod::DummyMod; level::Real = 0.95) =
     CoefTable(reshape(mod.beta, (size(mod.beta,1), 1)),
               ["'beta' value"],
               ["" for n in 1:size(mod.x,2)],
@@ -159,7 +159,7 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
     @test length(predict(m, d2)) == 4
 
     ## test copying of names from Terms to CoefTable
-    ct = coeftable(m)
+    ct = coeftable(m; level = 0.9)
     @test ct.rownms == ["(Intercept)", "x1", "x2", "x1 & x2"]
     @test termnames(m) == ("y", ["(Intercept)", "x1", "x2", "x1 & x2"])
 


### PR DESCRIPTION
It ends up being passed as a positional argument but it should be passed as a keyword argument, see https://github.com/JuliaStats/StatsAPI.jl/blob/20b38e1f73d70fe528097f2f23d662e8830e14ad/src/statisticalmodel.jl#L23, and that is also how GLM defines `coeftable`.