### PR TITLE
Fix issue with \times in docstring

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -471,7 +471,7 @@ end
     HypothesisCoding(hypotheses::AbstractMatrix; levels=nothing, labels=nothing)
 
 Specify how to code a categorical variable in terms of a *hypothesis matrix*.
-For a variable with ``k`` levels, this should be a ``k-1 \times k`` matrix.
+For a variable with ``k`` levels, this should be a ``k-1×k`` matrix.
 Each row of the matrix corresponds to a hypothesis about the mean
 outcomes under each of the ``k`` levels of the predictor.  The entries in the
 row give the weights assigned to each of these ``k`` means, and the

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -471,7 +471,7 @@ end
     HypothesisCoding(hypotheses::AbstractMatrix; levels=nothing, labels=nothing)
 
 Specify how to code a categorical variable in terms of a *hypothesis matrix*.
-For a variable with ``k`` levels, this should be a ``k-1×k`` matrix.
+For a variable with ``k`` levels, this should be a ``(k-1) × k`` matrix.
 Each row of the matrix corresponds to a hypothesis about the mean
 outcomes under each of the ``k`` levels of the predictor.  The entries in the
 row give the weights assigned to each of these ``k`` means, and the


### PR DESCRIPTION
Replaced \times with × that will work in both docstring and docs.