### PR TITLE
Fix show method for TableModels

### DIFF
--- a/src/statsmodel.jl
+++ b/src/statsmodel.jl
@@ -194,17 +194,17 @@ function StatsAPI.coeftable(model::TableModels; kwargs...)
 end
 
 # show function that delegates to coeftable
-function Base.show(io::IO, model::TableModels)
+function Base.show(io::IO, ::MIME"text/plain", model::TableModels)
     println(io, typeof(model))
     println(io)
     println(io, model.mf.f)
     println(io)
     try
         println(io,"Coefficients:")
-        show(io, coeftable(model))
+        show(io, MIME"text/plain"(), coeftable(model))
     catch e
         if isa(e, MethodError) || isa(e, ErrorException) && occursin("coeftable is not defined", e.msg)
-            show(io, model.model)
+            show(io, MIME"text/plain"(), model.model)
         else
             rethrow(e)
         end

--- a/test/statsmodel.jl
+++ b/test/statsmodel.jl
@@ -106,7 +106,7 @@ struct DummyModTwo <: RegressionModel
 end
 
 StatsAPI.fit(::Type{DummyModTwo}, ::Matrix, ::Vector) = DummyModTwo("hello!")
-Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
+Base.show(io::IO, m::DummyModTwo) = print(io, m.msg)
 
 @testset "stat model types" begin
 
@@ -164,8 +164,20 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
     @test termnames(m) == ("y", ["(Intercept)", "x1", "x2", "x1 & x2"])
 
     ## show with coeftable defined
-    io = IOBuffer()
-    show(io, m)
+    @test repr("text/plain", m) == """
+        StatsModels.TableRegressionModel{DummyMod, Matrix{Float64}}
+
+        y ~ 1 + x1 + x2 + x1 & x2
+
+        Coefficients:
+        ─────────────────────────
+                     'beta' value
+        ─────────────────────────
+        (Intercept)           1.0
+        x1                    2.0
+        x2                    3.0
+        x1 & x2               4.0
+        ─────────────────────────"""
 
     ## with categorical variables
     f2 = @formula(y ~ x1p)
@@ -234,7 +246,13 @@ Base.show(io::IO, m::DummyModTwo) = println(io, m.msg)
 
     m2 = fit(DummyModTwo, f, d)
     # make sure show() still works when there is no coeftable method
-    show(io, m2)
+    @test repr("text/plain", m2) == """
+        StatsModels.TableRegressionModel{DummyModTwo, Matrix{Float64}}
+
+        y ~ 1 + x1 + x2 + x1 & x2
+
+        Coefficients:
+        hello!"""
 end
 
 @testset "termnames" begin


### PR DESCRIPTION
Similar to and surfaced by https://github.com/JuliaStats/StatsBase.jl/pull/986

After https://github.com/JuliaStats/StatsBase.jl/pull/986, the show method here gives
```julia
julia> m
StatsModels.TableRegressionModel{DummyMod, Matrix{Float64}}

y ~ 1 + x1 + x2 + x1 & x2

Coefficients:
CoefTable(Any[[1.0, 2.0, 3.0, 4.0]], ["'beta' value"], ["(Intercept)", "x1", "x2", "x1 & x2"], 0, 0)
```

and with the fix here it becomes
```julia
julia> m
StatsModels.TableRegressionModel{DummyMod, Matrix{Float64}}

y ~ 1 + x1 + x2 + x1 & x2

Coefficients:
─────────────────────────
             'beta' value
─────────────────────────
(Intercept)           1.0
x1                    2.0
x2                    3.0
x1 & x2               4.0
─────────────────────────
```