### PR TITLE
fix CategoricalArrays #330

### DIFF
--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -289,7 +289,7 @@ mutable struct FullDummyCoding <: AbstractContrasts
 end
 
 ContrastsMatrix(C::FullDummyCoding, levels::AbstractVector{T}) where {T} =
-    ContrastsMatrix(Matrix(1.0I, length(levels), length(levels)), levels, levels, C)
+    ContrastsMatrix(Matrix(1.0I, length(levels), length(levels)), Vector(levels), Vector(levels), C)
 
 "Promote contrasts matrix to full rank version"
 Base.convert(::Type{ContrastsMatrix{FullDummyCoding}}, C::ContrastsMatrix) =


### PR DESCRIPTION
I don't know is it bug or feature, but this code doesn't work with 0.7.8:

```julia
using StatsModels, CategoricalArrays
data = (a = [1,2,3], b = ["2", "2", "3"], c=categorical([1,2,3]))
c1 = Dict(:a => StatsModels.FullDummyCoding())
c2 = Dict(:b => StatsModels.FullDummyCoding())
c3 = Dict(:c => StatsModels.FullDummyCoding())
StatsModels.schema(data, c1) # Fine
StatsModels.schema(data, c2) # Fine
StatsModels.schema(data, c3) # ERROR
```

with this fix it seems work... see #330 for details. If this PR is not relevant - just delete. 