### PR TITLE
ContrastsMatrix constructor accepts AbstractVector (including CategoricalArray)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.7.8"
+version = "0.7.9"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"

--- a/src/contrasts.jl
+++ b/src/contrasts.jl
@@ -108,12 +108,12 @@ struct ContrastsMatrix{C <: AbstractContrasts, M <: AbstractMatrix, T, U}
     contrasts::C
     invindex::Dict{T,Int}
     function ContrastsMatrix(matrix::M,
-                             coefnames::Vector{U},
-                             levels::Vector{T},
+                             coefnames::AbstractVector{U},
+                             levels::AbstractVector{T},
                              contrasts::C) where {U, T, C <: AbstractContrasts, M <: AbstractMatrix}
         allunique(levels) || throw(ArgumentError("levels must be all unique, got $(levels)"))
         invindex = Dict{T,Int}(x=>i for (i,x) in enumerate(levels))
-        new{C,M,T,U}(matrix, coefnames, levels, contrasts, invindex)
+        new{C,M,T,U}(matrix, convert(Vector{U}, coefnames), convert(Vector{T}, levels), contrasts, invindex)
     end
 end
 

--- a/test/contrasts.jl
+++ b/test/contrasts.jl
@@ -418,4 +418,18 @@
         @test issetequal(cm.levels, [true, false])
     end
 
+
+    @testset "FullDummy and AbstractVector (#337)" begin
+        cm = ContrastsMatrix(StatsModels.FullDummyCoding(), categorical([1, 2, 3]))
+        @test cm.levels == cm.coefnames == categorical([1, 2, 3])
+        @test cm.levels isa Vector{<:CategoricalValue}
+        @test cm.coefnames isa Vector{<:CategoricalValue}
+        @test cm.matrix == I(3)
+
+        cm = ContrastsMatrix(StatsModels.FullDummyCoding(), view([1 2 3], 1, 1:3))
+        @test cm.levels == cm.coefnames == [1, 2, 3]
+        @test cm.levels isa Vector{Int}
+        @test cm.coefnames isa Vector{Int}
+        @test cm.matrix == I(3)
+    end
 end


### PR DESCRIPTION
closes #330 and closes #337

In addition to the example that @PharmCat constructed with a categorical array, you would also run into trouble with anything involving views with the old behavior.