### PR TITLE
Add support for StatsFuns@2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StatsModels"
 uuid = "3eaba693-59b7-5ba5-a881-562e759f1c8d"
-version = "0.7.9"
+version = "0.7.10"
 
 [deps]
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
@@ -29,7 +29,7 @@ SparseArrays = "<0.0.1, 1"
 Statistics = "1"
 StatsAPI = "1.7"
 StatsBase = "0.33.5, 0.34"
-StatsFuns = "0.9, 1.0"
+StatsFuns = "0.9, 1, 2"
 Tables = "0.2, 1"
 Test = "1"
 TestSetExtensions = "3"


### PR DESCRIPTION
In StatsFuns@2, the Rmath-based sampling methods and the internal `StatsFuns.RFunctions` module are removed. This is not technically breaking but in practice breaks some existing Distributions releases, hence I put it into a breaking release.